### PR TITLE
Add Radio Browser fragment

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/search/RadioBrowserHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/search/RadioBrowserHelper.kt
@@ -10,11 +10,11 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 object RadioBrowserHelper {
-    private const val BASE_URL = "https://de1.api.radio-browser.info/json/stations/byname/"
+    private const val BASE_URL = "https://de1.api.radio-browser.info"
 
-    suspend fun searchStations(query: String): List<RadioBrowserResult> = withContext(Dispatchers.IO) {
+    private suspend fun performRequest(endpoint: String): List<RadioBrowserResult> = withContext(Dispatchers.IO) {
         try {
-            val apiUrl = "$BASE_URL$query"
+            val apiUrl = "$BASE_URL$endpoint"
             val url = URL(apiUrl)
             val connection = url.openConnection() as HttpURLConnection
             connection.requestMethod = "GET"
@@ -25,7 +25,7 @@ object RadioBrowserHelper {
                 val inputStream = connection.inputStream
                 val json = inputStream.bufferedReader().use { it.readText() }
                 val type = object : TypeToken<List<RadioBrowserResult>>() {}.type
-                Gson().fromJson(json, type)
+                Gson().fromJson<List<RadioBrowserResult>>(json, type)
             } else {
                 Log.e("RadioBrowserHelper", "HTTP error: ${connection.responseCode}")
                 emptyList()
@@ -34,6 +34,14 @@ object RadioBrowserHelper {
             Log.e("RadioBrowserHelper", "Error: ${e.localizedMessage}")
             emptyList()
         }
+    }
+
+    suspend fun searchStations(query: String): List<RadioBrowserResult> {
+        return performRequest("/json/stations/byname/$query")
+    }
+
+    suspend fun getTopStations(limit: Int): List<RadioBrowserResult> {
+        return performRequest("/json/stations/topclick/$limit")
     }
 }
     

--- a/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import android.widget.Switch
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.ui.RadioBrowserFragment
 
 class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
 
@@ -40,6 +41,12 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
             openStationsFragment()
         }
 
+        // Radio Browser
+        view.findViewById<LinearLayout>(R.id.option_radio_browser).setOnClickListener {
+            dismiss()
+            openRadioBrowserFragment()
+        }
+
         // Einstellungen (Settings)
         view.findViewById<LinearLayout>(R.id.option_settings).setOnClickListener {
             dismiss()
@@ -66,6 +73,14 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
         parentFragmentManager.beginTransaction()
             .setReorderingAllowed(true)
             .replace(R.id.fragment_container, StationsFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    private fun openRadioBrowserFragment() {
+        parentFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .replace(R.id.fragment_container, RadioBrowserFragment())
             .addToBackStack(null)
             .commit()
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/RadioBrowserFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/RadioBrowserFragment.kt
@@ -1,0 +1,82 @@
+package at.plankt0n.streamplay.ui
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.adapter.SearchResultAdapter
+import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.search.RadioBrowserHelper
+import kotlinx.coroutines.launch
+
+class RadioBrowserFragment : Fragment() {
+
+    private val results = mutableListOf<StationItem>()
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: SearchResultAdapter
+    private lateinit var searchInput: EditText
+    private lateinit var topbarBackButton: ImageButton
+    private lateinit var topbarTitle: TextView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_radio_browser, container, false)
+
+        topbarBackButton = view.findViewById(R.id.arrow_back)
+        topbarTitle = view.findViewById(R.id.topbar_title)
+        topbarTitle.text = getString(R.string.fragment_radio_browser_title)
+
+        searchInput = view.findViewById(R.id.edit_search)
+        recyclerView = view.findViewById(R.id.recyclerViewRadioResults)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        adapter = SearchResultAdapter(results) { selected ->
+            val current = PreferencesHelper.getStations(requireContext()).toMutableList()
+            current.add(selected)
+            PreferencesHelper.saveStations(requireContext(), current)
+        }
+        recyclerView.adapter = adapter
+
+        lifecycleScope.launch {
+            val top = RadioBrowserHelper.getTopStations(20)
+            results.clear()
+            results.addAll(top.map { it.toStationItem() })
+            adapter.notifyDataSetChanged()
+        }
+
+        searchInput.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {}
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val query = s?.toString()?.trim() ?: return
+                if (query.length >= 3) {
+                    lifecycleScope.launch {
+                        val resultsApi = RadioBrowserHelper.searchStations(query)
+                        results.clear()
+                        results.addAll(resultsApi.map { it.toStationItem() })
+                        adapter.notifyDataSetChanged()
+                    }
+                }
+            }
+        })
+
+        topbarBackButton.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+
+        return view
+    }
+}

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -47,7 +47,33 @@
             android:textAppearance="?attr/textAppearanceBody1" />
     </LinearLayout>
 
-    <!-- Eintrag 2: Settings -->
+    <!-- Eintrag 2: Radio Browser -->
+    <LinearLayout
+        android:id="@+id/option_radio_browser"
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp"
+        android:clickable="true"
+        android:foreground="?attr/selectableItemBackground">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_radio"
+            android:contentDescription="@string/bottom_sheet_radio_browser_desc"
+            android:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="16dp"
+            android:text="@string/bottom_sheet_radio_browser_text"
+            android:textAppearance="?attr/textAppearanceBody1" />
+    </LinearLayout>
+
+    <!-- Eintrag 3: Settings -->
     <LinearLayout
         android:id="@+id/option_settings"
         android:orientation="horizontal"

--- a/app/src/main/res/layout/fragment_radio_browser.xml
+++ b/app/src/main/res/layout/fragment_radio_browser.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/topbar" />
+
+    <EditText
+        android:id="@+id/edit_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/radio_browser_search_hint" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewRadioResults"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
     <!-- Topbar -->
     <string name="descr_back_icon">Navigate back</string>
     <string name="fragment_stations_title">Stations</string>
+    <string name="fragment_radio_browser_title">Radio Browser</string>
+    <string name="radio_browser_search_hint">Search…</string>
 
     <!-- Player Fragment -->
     <string name="unknown_title">No Title Information</string>
@@ -82,6 +84,8 @@
     <!-- Option 2: Einstellungen -->
     <string name="bottom_sheet_settings_text">Einstellungen</string>
     <string name="bottom_sheet_settings_content_desc">Einstellungen öffnen</string>
+    <string name="bottom_sheet_radio_browser_text">Browse Stations</string>
+    <string name="bottom_sheet_radio_browser_desc">Browse online stations</string>
     <!-- Option 4: Autostart -->
     <string name="bottom_sheet_autostart">Autostart</string>
 </resources>


### PR DESCRIPTION
## Summary
- extend `RadioBrowserHelper` with `getTopStations`
- add new `RadioBrowserFragment` and layout
- enable Radio Browser from bottom sheet
- add related strings and layout updates

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1f39c1c8832fbdc1c08503e7fdb0