### PR TITLE
Switch to Station model and update station UI

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -28,7 +28,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.extractor.metadata.icy.IcyInfo
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import at.plankt0n.streamplay.helper.IcyStreamReader
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.SpotifyMetaReader
@@ -49,7 +49,7 @@ class StreamingService : MediaSessionService() {
     private lateinit var player: ExoPlayer
     private lateinit var mediaSession: MediaSession
 
-    private var streams: List<StationItem> = emptyList()
+    private var streams: List<Station> = emptyList()
     private var mediaItems: List<MediaItem> = emptyList()
     private var currentIndex = 0
 
@@ -176,9 +176,9 @@ class StreamingService : MediaSessionService() {
 
         mediaItems = streams.map {
             val extras = Bundle().apply {
-                putString("EXTRA_ICON_URL", it.iconURL)
+                putString("EXTRA_ICON_URL", it.image)
                 putString("EXTRA_UUID", it.uuid)
-                putString("EXTRA_STATION_NAME", it.stationName)
+                putString("EXTRA_STATION_NAME", it.name)
             }
 
             val metadata = MediaMetadata.Builder()
@@ -187,7 +187,7 @@ class StreamingService : MediaSessionService() {
 
             MediaItem.Builder()
 
-                .setUri(it.streamURL)
+                .setUri(it.getStreamUri())
                 .setMediaMetadata(metadata)
                 .build()
         }
@@ -214,9 +214,9 @@ class StreamingService : MediaSessionService() {
 
         mediaItems = streams.map {
             val extras = Bundle().apply {
-                putString("EXTRA_ICON_URL", it.iconURL)
+                putString("EXTRA_ICON_URL", it.image)
                 putString("EXTRA_UUID", it.uuid)
-                putString("EXTRA_STATION_NAME", it.stationName)
+                putString("EXTRA_STATION_NAME", it.name)
             }
 
             val metadata = MediaMetadata.Builder()
@@ -224,7 +224,7 @@ class StreamingService : MediaSessionService() {
                 .build()
 
             MediaItem.Builder()
-                .setUri(it.streamURL)
+                .setUri(it.getStreamUri())
                 .setMediaMetadata(metadata)
                 .build()
         }
@@ -462,15 +462,15 @@ val title = refreshMetaData?.title?.toString().orEmpty()
     }
 
 
-    fun isPlaylistDifferent(current: List<StationItem>, new: List<StationItem>): Boolean {
+    fun isPlaylistDifferent(current: List<Station>, new: List<Station>): Boolean {
         if (current.size != new.size) return true
         for (i in current.indices) {
             val oldItem = current[i]
             val newItem = new[i]
             if (oldItem.uuid != newItem.uuid ||
-                oldItem.stationName != newItem.stationName ||
-                oldItem.streamURL != newItem.streamURL ||
-                oldItem.iconURL != newItem.iconURL) {
+                oldItem.name != newItem.name ||
+                oldItem.getStreamUri() != newItem.getStreamUri() ||
+                oldItem.image != newItem.image) {
                 return true
             }
         }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
@@ -11,7 +11,7 @@ import android.view.ViewGroup
 import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import at.plankt0n.streamplay.helper.MediaServiceController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.BitmapImageViewTarget
@@ -21,7 +21,7 @@ class CoverPageAdapter(
     private val mediaServiceController: MediaServiceController
 ) : RecyclerView.Adapter<CoverPageAdapter.CoverViewHolder>() {
 
-    val mediaItems: List<StationItem> = mediaServiceController.getCurrentPlaylist()
+    val mediaItems: List<Station> = mediaServiceController.getCurrentPlaylist()
 
     inner class CoverViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val coverImage: ShapeableImageView = itemView.findViewById(R.id.cover_image)
@@ -39,7 +39,7 @@ class CoverPageAdapter(
 
         Glide.with(holder.itemView)
             .asBitmap()
-            .load(item.iconURL)
+            .load(item.image)
             .placeholder(R.drawable.ic_placeholder_logo)
             .error(R.drawable.ic_stationcover_placeholder)
             .into(object : BitmapImageViewTarget(holder.coverImage) {

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
@@ -8,12 +8,12 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import com.bumptech.glide.Glide
 
 class SearchResultAdapter(
-    private val searchResults: List<StationItem>,
-    private val onClick: (StationItem) -> Unit
+    private val searchResults: List<Station>,
+    private val onClick: (Station) -> Unit
 ) : RecyclerView.Adapter<SearchResultAdapter.ViewHolder>() {
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -32,11 +32,11 @@ class SearchResultAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val result = searchResults[position]
-        holder.textStationName.text = result.stationName
-        holder.textStreamUrl.text = result.streamURL
+        holder.textStationName.text = result.name
+        holder.textStreamUrl.text = result.getStreamUri()
 
         Glide.with(holder.imageLogo.context)
-            .load(result.iconURL)
+            .load(result.image)
             .placeholder(R.drawable.ic_stationcover_placeholder)
             .into(holder.imageLogo)
 

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -6,11 +6,11 @@ import android.view.ViewGroup
 import android.widget.*
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import at.plankt0n.streamplay.helper.PreferencesHelper
 
 class StationListAdapter(
-    private val stationList: MutableList<StationItem>
+    private val stationList: MutableList<Station>
 ) : RecyclerView.Adapter<StationListAdapter.ViewHolder>() {
 
     private var editingPosition: Int = -1
@@ -43,13 +43,13 @@ class StationListAdapter(
         val station = stationList[position]
 
         // Normale Ansicht
-        holder.textName.text = station.stationName
-        holder.textUrl.text = station.streamURL
+        holder.textName.text = station.name
+        holder.textUrl.text = station.getStreamUri()
 
         // Editieransicht füllen
-        holder.editName.setText(station.stationName)
-        holder.editUrl.setText(station.streamURL)
-        holder.editIcon.setText(station.iconURL)
+        holder.editName.setText(station.name)
+        holder.editUrl.setText(station.getStreamUri())
+        holder.editIcon.setText(station.image)
 
         // Sichtbarkeiten
         val isEditing = (position == editingPosition)
@@ -66,9 +66,10 @@ class StationListAdapter(
         // Speichern
         holder.buttonSave.setOnClickListener {
             val updatedStation = station.copy(
-                stationName = holder.editName.text.toString(),
-                streamURL = holder.editUrl.text.toString(),
-                iconURL = holder.editIcon.text.toString()
+                name = holder.editName.text.toString(),
+                streamUris = mutableListOf(holder.editUrl.text.toString()),
+                image = holder.editIcon.text.toString(),
+                smallImage = holder.editIcon.text.toString()
             )
             stationList[position] = updatedStation
             PreferencesHelper.saveStations(holder.itemView.context, stationList)

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -14,7 +14,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import java.lang.Thread.State
 
 class MediaServiceController(private val context: Context) {
@@ -110,10 +110,10 @@ class MediaServiceController(private val context: Context) {
             controller.play()
         }
     }
-    fun getCurrentPlaylist(): List<StationItem> {
+    fun getCurrentPlaylist(): List<Station> {
         val controller = mediaController ?: return emptyList()
         val itemCount = controller.mediaItemCount
-        val streams = mutableListOf<StationItem>()
+        val streams = mutableListOf<Station>()
 
         for (i in 0 until itemCount) {
             val mediaItem = controller.getMediaItemAt(i)
@@ -126,11 +126,12 @@ class MediaServiceController(private val context: Context) {
             val iconUrl = extras?.getString("EXTRA_ICON_URL") ?: ""
             val name = extras?.getString("EXTRA_STATION_NAME") ?: ""
             streams.add(
-                StationItem(
+                Station(
                     uuid = uuid,
-                    stationName = name,
-                    streamURL = url,
-                    iconURL = iconUrl
+                    name = name,
+                    streamUris = mutableListOf(url),
+                    image = iconUrl,
+                    smallImage = iconUrl
                 )
             )
         }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -3,7 +3,7 @@ package at.plankt0n.streamplay.helper
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
@@ -17,17 +17,17 @@ object PreferencesHelper {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
 
-    fun getStations(context: Context): MutableList<StationItem> {
+    fun getStations(context: Context): MutableList<Station> {
         val json = getPrefs(context).getString(KEY_STATIONS, null)
         return if (json != null) {
-            val type = object : TypeToken<MutableList<StationItem>>() {}.type
+            val type = object : TypeToken<MutableList<Station>>() {}.type
             Gson().fromJson(json, type)
         } else {
             mutableListOf()
         }
     }
 
-    fun saveStations(context: Context, stationList: List<StationItem>) {
+    fun saveStations(context: Context, stationList: List<Station>) {
         val json = Gson().toJson(stationList)
         getPrefs(context).edit().putString(KEY_STATIONS, json).apply()
     }

--- a/app/src/main/java/at/plankt0n/streamplay/search/RadioBrowserResult.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/search/RadioBrowserResult.kt
@@ -16,7 +16,7 @@ package at.plankt0n.streamplay.search
 
 import com.google.gson.annotations.Expose
 import at.plankt0n.streamplay.Keys
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import java.util.GregorianCalendar
 
 
@@ -34,12 +34,19 @@ data class RadioBrowserResult(
     @Expose val codec: String,
     @Expose val bitrate: Int
 ) {
-    /* Converts RadioBrowserResult to StationItem */
-    fun toStationItem(): StationItem = StationItem(
+    /* Converts RadioBrowserResult to Station */
+    fun toStation(): Station = Station(
         uuid = stationuuid,
-        stationName = name,
-        streamURL = url,
-        iconURL = favicon
+        name = name,
+        streamUris = mutableListOf(url),
+        image = favicon,
+        smallImage = favicon,
+        modificationDate = GregorianCalendar().time,
+        codec = codec,
+        bitrate = bitrate,
+        radioBrowserStationUuid = stationuuid,
+        radioBrowserChangeUuid = changeuuid,
+        homepage = homepage
     )
 }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -13,6 +13,7 @@ import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -22,7 +23,7 @@ import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.adapter.SearchResultAdapter
 import at.plankt0n.streamplay.adapter.StationListAdapter
-import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.data.Station
 import at.plankt0n.streamplay.helper.PlaylistURLHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.StateHelper
@@ -31,10 +32,11 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.launch
 import java.util.*
+import java.util.Collections
 
 class StationsFragment : Fragment() {
 
-    private lateinit var stationList: MutableList<StationItem>
+    private lateinit var stationList: MutableList<Station>
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: StationListAdapter
     private lateinit var topbarBackButton: ImageButton
@@ -60,12 +62,19 @@ class StationsFragment : Fragment() {
         adapter = StationListAdapter(stationList)
         recyclerView.adapter = adapter
 
-        val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT) {
+        val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP or ItemTouchHelper.DOWN, ItemTouchHelper.LEFT) {
             override fun onMove(
                 recyclerView: RecyclerView,
                 viewHolder: RecyclerView.ViewHolder,
                 target: RecyclerView.ViewHolder
-            ) = false
+            ): Boolean {
+                val fromPos = viewHolder.adapterPosition
+                val toPos = target.adapterPosition
+                Collections.swap(stationList, fromPos, toPos)
+                adapter.notifyItemMoved(fromPos, toPos)
+                PreferencesHelper.saveStations(requireContext(), stationList)
+                return true
+            }
 
             override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
                 val position = viewHolder.adapterPosition
@@ -111,6 +120,7 @@ class StationsFragment : Fragment() {
             .inflate(R.layout.dialog_search_station, null)
         val editSearch = dialogView.findViewById<EditText>(R.id.editSearchQuery)
         val recyclerView = dialogView.findViewById<RecyclerView>(R.id.recyclerViewSearchResults)
+        val buttonManualAdd = dialogView.findViewById<Button>(R.id.buttonManualAdd)
 
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
 
@@ -134,16 +144,16 @@ class StationsFragment : Fragment() {
                 } else if (query.length >= 3) {
                     lifecycleScope.launch {
                         val results = RadioBrowserHelper.searchStations(query)
-                        val stationItems = results.map { it.toStationItem() }
+                        val stationItems = results.map { it.toStation() }
                         recyclerView.adapter = SearchResultAdapter(stationItems) { selected ->
                             lifecycleScope.launch {
-                                val finalUrl = if (selected.streamURL.endsWith(".m3u", true) || selected.streamURL.endsWith(".pls", true)) {
-                                    PlaylistURLHelper.resolvePlaylistUrl(selected.streamURL) ?: selected.streamURL
+                                val finalUrl = if (selected.getStreamUri().endsWith(".m3u", true) || selected.getStreamUri().endsWith(".pls", true)) {
+                                    PlaylistURLHelper.resolvePlaylistUrl(selected.getStreamUri()) ?: selected.getStreamUri()
                                 } else {
-                                    selected.streamURL
+                                    selected.getStreamUri()
                                 }
 
-                                val station = selected.copy(streamURL = finalUrl)
+                                val station = selected.copy(streamUris = mutableListOf(finalUrl))
                                 stationList.add(station)
                                 PreferencesHelper.saveStations(requireContext(), stationList)
                                 adapter.notifyItemInserted(stationList.size - 1)
@@ -155,7 +165,43 @@ class StationsFragment : Fragment() {
             }
         })
 
+        buttonManualAdd.setOnClickListener {
+            dialog.dismiss()
+            showManualAddDialog()
+        }
+
         dialog.show()
+    }
+
+    private fun showManualAddDialog() {
+        val view = LayoutInflater.from(requireContext())
+            .inflate(R.layout.dialog_add_station, null)
+
+        val editName = view.findViewById<EditText>(R.id.editStationName)
+        val editUrl = view.findViewById<EditText>(R.id.editStreamUrl)
+        val editIcon = view.findViewById<EditText>(R.id.editIconUrl)
+
+        android.app.AlertDialog.Builder(requireContext())
+            .setTitle("Manuell hinzufügen")
+            .setView(view)
+            .setPositiveButton("Hinzufügen") { _, _ ->
+                val name = editName.text.toString()
+                val url = editUrl.text.toString()
+                val icon = editIcon.text.toString()
+                val station = Station(
+                    uuid = UUID.randomUUID().toString(),
+                    name = name,
+                    streamUris = mutableListOf(url),
+                    image = icon,
+                    smallImage = icon,
+                    modificationDate = Date()
+                )
+                stationList.add(station)
+                PreferencesHelper.saveStations(requireContext(), stationList)
+                adapter.notifyItemInserted(stationList.size - 1)
+            }
+            .setNegativeButton("Abbrechen", null)
+            .show()
     }
 
     private suspend fun resolveAndAddStation(url: String) {
@@ -165,11 +211,13 @@ class StationsFragment : Fragment() {
             url
         }
 
-        val station = StationItem(
+        val station = Station(
             uuid = UUID.randomUUID().toString(),
-            stationName = finalUrl,
-            streamURL = finalUrl,
-            iconURL = ""
+            name = finalUrl,
+            streamUris = mutableListOf(finalUrl),
+            image = "",
+            smallImage = "",
+            modificationDate = Date()
         )
         stationList.add(station)
         PreferencesHelper.saveStations(requireContext(), stationList)
@@ -189,23 +237,26 @@ class StationsFragment : Fragment() {
             var added = 0
 
             for (imported in importedList) {
-                val index = stationList.indexOfFirst { it.stationName.equals(imported.name, ignoreCase = true) }
+                val index = stationList.indexOfFirst { it.name.equals(imported.name, ignoreCase = true) }
                 if (index >= 0) {
                     val old = stationList[index]
-                    stationList[index] = StationItem(
-                        uuid = old.uuid,
-                        stationName = imported.name,
-                        streamURL = imported.url,
-                        iconURL = imported.iconUrl
+                    stationList[index] = old.copy(
+                        name = imported.name,
+                        streamUris = mutableListOf(imported.url),
+                        image = imported.iconUrl,
+                        smallImage = imported.iconUrl,
+                        modificationDate = Date()
                     )
                     updated++
                 } else {
                     stationList.add(
-                        StationItem(
+                        Station(
                             uuid = UUID.randomUUID().toString(),
-                            stationName = imported.name,
-                            streamURL = imported.url,
-                            iconURL = imported.iconUrl
+                            name = imported.name,
+                            streamUris = mutableListOf(imported.url),
+                            image = imported.iconUrl,
+                            smallImage = imported.iconUrl,
+                            modificationDate = Date()
                         )
                     )
                     added++

--- a/app/src/main/res/layout/dialog_search_station.xml
+++ b/app/src/main/res/layout/dialog_search_station.xml
@@ -17,5 +17,11 @@
         android:layout_width="match_parent"
         android:layout_height="300dp"
         android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/buttonManualAdd"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Manuell hinzufügen" />
 </LinearLayout>
     


### PR DESCRIPTION
## Summary
- use `Station` instead of `StationItem` across the app
- allow drag & drop reordering and manual station addition
- update adapters and playlist handling for new model
- persist `Station` objects in preferences

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b26e163ec832fbd50b92740644721