### PR TITLE
Update metadata when app background changes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("androidx.media:media:1.7.0")
+    implementation("androidx.lifecycle:lifecycle-process:2.8.0")
 
         // Media3 (aktuellste stabile Version 1.3.0 im Mai 2025 – Stand: 2025-05)
         val mediaVersion = "1.6.1"

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -16,6 +16,9 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
@@ -61,6 +64,23 @@ class StreamingService : MediaSessionService() {
         const val CHANNEL_ID = "stream_service_channel"
     }
 
+    private var hasSeenForeground = false
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            if (hasSeenForeground) {
+                refreshMediaItemMetadata()
+            } else {
+                hasSeenForeground = true
+            }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            if (hasSeenForeground) {
+                refreshMediaItemMetadata()
+            }
+        }
+    }
+
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST") {
@@ -72,6 +92,8 @@ class StreamingService : MediaSessionService() {
 
     override fun onCreate() {
         super.onCreate()
+
+        ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
 
         // ⚠️ ZUERST player initialisieren!
         val httpDataSourceFactory = DefaultHttpDataSource.Factory()
@@ -240,6 +262,7 @@ class StreamingService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(lifecycleObserver)
         mediaSession.release()
         player.release()
         super.onDestroy()


### PR DESCRIPTION
## Summary
- react to foreground/background events via `ProcessLifecycleOwner`
- invoke `refreshMediaItemMetadata` when app hides or returns
- add lifecycle-process dependency

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d48f7a8dc832f8e75598c6b6b1d47