### PR TITLE
Add playback control in stations list

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -12,16 +12,19 @@ import at.plankt0n.streamplay.helper.PreferencesHelper
 class StationListAdapter(
     private val stationList: MutableList<StationItem>,
     private val startDrag: (RecyclerView.ViewHolder) -> Unit,
-    private val onDataChanged: () -> Unit
+    private val onDataChanged: () -> Unit,
+    private val onPlayClick: (Int) -> Unit
 ) : RecyclerView.Adapter<StationListAdapter.ViewHolder>() {
 
     private var editingPosition: Int = -1
+    private var currentPlayingIndex: Int = -1
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         // Normale Ansicht
         val textName: TextView = itemView.findViewById(R.id.textStationName)
         val textUrl: TextView = itemView.findViewById(R.id.textStreamUrl)
         val dragHandle: ImageView = itemView.findViewById(R.id.dragHandle)
+        val playButton: ImageButton = itemView.findViewById(R.id.buttonPlayStation)
 
         // Editieransicht
         val editLayout: LinearLayout = itemView.findViewById(R.id.editLayout)
@@ -58,6 +61,16 @@ class StationListAdapter(
         val isEditing = (position == editingPosition)
         holder.normalLayout.visibility = if (isEditing) View.GONE else View.VISIBLE
         holder.editLayout.visibility = if (isEditing) View.VISIBLE else View.GONE
+
+        holder.playButton.visibility = if (isEditing) View.GONE else View.VISIBLE
+        holder.playButton.setOnClickListener { onPlayClick(position) }
+
+        val context = holder.itemView.context
+        if (position == currentPlayingIndex) {
+            holder.itemView.setBackgroundColor(context.getColor(R.color.highlight))
+        } else {
+            holder.itemView.setBackgroundColor(context.getColor(android.R.color.transparent))
+        }
 
         // Langes Drücken: In den Bearbeitungsmodus wechseln
         holder.itemView.setOnLongClickListener {
@@ -99,5 +112,10 @@ class StationListAdapter(
         java.util.Collections.swap(stationList, from, to)
         notifyItemMoved(from, to)
         onDataChanged()
+    }
+
+    fun setCurrentPlayingIndex(index: Int) {
+        currentPlayingIndex = index
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -26,6 +26,7 @@ import at.plankt0n.streamplay.adapter.StationListAdapter
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.PlaylistURLHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.StateHelper
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -37,6 +38,7 @@ class StationsFragment : Fragment() {
     private lateinit var stationList: MutableList<StationItem>
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: StationListAdapter
+    private lateinit var mediaServiceController: MediaServiceController
     private lateinit var topbarBackButton: ImageButton
     private lateinit var topbarTitle: TextView
 
@@ -123,13 +125,27 @@ class StationsFragment : Fragment() {
 
         val itemTouchHelper = ItemTouchHelper(simpleCallback)
 
+        mediaServiceController = MediaServiceController(requireContext())
+
         adapter = StationListAdapter(stationList, { holder ->
             itemTouchHelper.startDrag(holder)
-        }) {
+        }, {
             refreshPlaylist()
+        }) { index ->
+            mediaServiceController.playAtIndex(index)
         }
         recyclerView.adapter = adapter
         itemTouchHelper.attachToRecyclerView(recyclerView)
+
+        mediaServiceController.initializeAndConnect(
+            onConnected = { controller ->
+                adapter.setCurrentPlayingIndex(controller.currentMediaItemIndex)
+            },
+            onPlaybackChanged = {},
+            onStreamIndexChanged = { idx -> adapter.setCurrentPlayingIndex(idx) },
+            onMetadataChanged = {},
+            onTimelineChanged = {}
+        )
 
         view.findViewById<View>(R.id.buttonAddStation).setOnClickListener {
             showAddDialog()
@@ -259,4 +275,9 @@ class StationsFragment : Fragment() {
         val url: String,
         val iconUrl: String
     )
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        mediaServiceController.disconnect()
+    }
 }

--- a/app/src/main/res/layout/item_station_editable.xml
+++ b/app/src/main/res/layout/item_station_editable.xml
@@ -12,13 +12,22 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <ImageButton
+            android:id="@+id/buttonPlayStation"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_button_play_station"
+            android:src="@drawable/ic_button_play"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true" />
+
         <LinearLayout
             android:id="@+id/stationTexts"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
+            android:layout_toEndOf="@id/buttonPlayStation"
             android:layout_toStartOf="@+id/dragHandle">
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,9 @@
 
     <string name="drag_handle_desc">Move station</string>
 
+    <!-- Stations Fragment play button -->
+    <string name="desc_button_play_station">Play this station</string>
+
     <!-- Discover Fragment -->
     <string name="discover_title">Discover</string>
     <string name="search_hint">Search stations</string>


### PR DESCRIPTION
## Summary
- allow selecting the playing stream from the stations list
- display a play button and highlight the active station
- use `MediaServiceController` in `StationsFragment` for playback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0440da4832f9e787afd8994e957