### PR TITLE
Fix stations scrolling and shortcut icons

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
@@ -40,7 +40,9 @@ class ShortcutAdapter(
         holder.labelTextView.text = item.label
         Glide.with(holder.itemView)
             .load(item.iconUrl)
+            .centerCrop()
             .placeholder(R.drawable.ic_placeholder_logo)
+            .error(R.drawable.ic_placeholder_logo)
             .into(holder.iconImageView)
 
         holder.itemView.setOnClickListener { onClick(item) }

--- a/app/src/main/res/layout/fragment_stations.xml
+++ b/app/src/main/res/layout/fragment_stations.xml
@@ -18,5 +18,6 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewStations"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- make station list recyclerview fill remaining space so it scrolls correctly
- load shortcut icons with center cropping and fallback errors

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcf5a4b20832fadff4fde6c511f73