### PR TITLE
Update metadata when stream changes

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -122,11 +122,20 @@ class StreamingService : MediaSessionService() {
                         Log.d("StreamingService", "💾 Index gespeichert: $currentIndex")
                         UITrackViewModel.clearTrackInfo()
 
-
                         PreferencesHelper.setLastPlayedStreamIndex(
                             this@StreamingService,
                             currentIndex
                         )
+
+                        // Force metadata update for the new stream
+                        lastIcyMetadata = null
+                        val mm = player.mediaMetadata
+                        if (mm != MediaMetadata.EMPTY) {
+                            val icy = IcyInfo.Builder()
+                                .setTitle("${mm.artist ?: ""} - ${mm.title ?: ""}")
+                                .build()
+                            fetchMetadata(Metadata(icy))
+                        }
 
                     }
                     //Listener für errors

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -129,13 +129,13 @@ class StreamingService : MediaSessionService() {
 
                         // Force metadata update for the new stream
                         lastIcyMetadata = null
-                        val mm = player.mediaMetadata
-                        if (mm != MediaMetadata.EMPTY) {
-                            val icy = IcyInfo.Builder()
-                                .setTitle("${mm.artist ?: ""} - ${mm.title ?: ""}")
-                                .build()
-                            fetchMetadata(Metadata(icy))
-                        }
+                        fetchMetadata(
+                            Metadata(
+                                IcyInfo.Builder()
+                                    .setTitle("${player.mediaMetadata.artist ?: ""} - ${player.mediaMetadata.title ?: ""}")
+                                    .build()
+                            )
+                        )
 
                     }
                     //Listener für errors


### PR DESCRIPTION
## Summary
- trigger metadata fetch on every `onMediaItemTransition`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd571d254832f935cab5e5a3eea47