### PR TITLE
Fix scroll in station list and remove top bar

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -146,6 +146,7 @@ class StationsFragment : Fragment() {
                     startX = event.x
                     startY = event.y
                     orientationDecided = false
+                    parentPager?.requestDisallowInterceptTouchEvent(true)
                 }
                 MotionEvent.ACTION_MOVE -> {
                     if (!orientationDecided) {
@@ -153,7 +154,8 @@ class StationsFragment : Fragment() {
                         val dy = abs(event.y - startY)
                         if (dx > touchSlop || dy > touchSlop) {
                             orientationDecided = true
-                            parentPager?.requestDisallowInterceptTouchEvent(dy > dx)
+                            val isVertical = dy > dx
+                            parentPager?.requestDisallowInterceptTouchEvent(isVertical)
                         }
                     }
                 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -138,26 +138,29 @@ class StationsFragment : Fragment() {
         val parentPager = parentFragment?.view?.findViewById<ViewPager2>(R.id.main_view_pager)
         var startX = 0f
         var startY = 0f
-        var scrollingVertically = false
+        var orientationDecided = false
         val touchSlop = ViewConfiguration.get(requireContext()).scaledTouchSlop
         recyclerView.setOnTouchListener { _, event ->
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
                     startX = event.x
                     startY = event.y
-                    scrollingVertically = false
+                    orientationDecided = false
+                    parentPager?.requestDisallowInterceptTouchEvent(true)
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    val dx = abs(event.x - startX)
-                    val dy = abs(event.y - startY)
-                    if (!scrollingVertically && (dx > touchSlop || dy > touchSlop)) {
-                        scrollingVertically = dy > dx
+                    if (!orientationDecided) {
+                        val dx = abs(event.x - startX)
+                        val dy = abs(event.y - startY)
+                        if (dx > touchSlop || dy > touchSlop) {
+                            orientationDecided = true
+                            parentPager?.requestDisallowInterceptTouchEvent(dy > dx)
+                        }
                     }
-                    parentPager?.requestDisallowInterceptTouchEvent(scrollingVertically)
                 }
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     parentPager?.requestDisallowInterceptTouchEvent(false)
-                    scrollingVertically = false
+                    orientationDecided = false
                 }
             }
             false

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -134,12 +134,29 @@ class StationsFragment : Fragment() {
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
         val parentPager = parentFragment?.view?.findViewById<ViewPager2>(R.id.main_view_pager)
+        var startX = 0f
+        var startY = 0f
+        var scrollingVertically = false
+        val touchSlop = ViewConfiguration.get(requireContext()).scaledTouchSlop
         recyclerView.setOnTouchListener { _, event ->
             when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE ->
-                    parentPager?.requestDisallowInterceptTouchEvent(true)
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+                MotionEvent.ACTION_DOWN -> {
+                    startX = event.x
+                    startY = event.y
+                    scrollingVertically = false
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val dx = abs(event.x - startX)
+                    val dy = abs(event.y - startY)
+                    if (!scrollingVertically && (dx > touchSlop || dy > touchSlop)) {
+                        scrollingVertically = dy > dx
+                    }
+                    parentPager?.requestDisallowInterceptTouchEvent(scrollingVertically)
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     parentPager?.requestDisallowInterceptTouchEvent(false)
+                    scrollingVertically = false
+                }
             }
             false
         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -8,8 +8,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
-import android.widget.ImageButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -29,7 +27,6 @@ import at.plankt0n.streamplay.helper.PlaylistURLHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.StateHelper
-import at.plankt0n.streamplay.MainActivity
 import androidx.viewpager2.widget.ViewPager2
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -42,8 +39,6 @@ class StationsFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: StationListAdapter
     private lateinit var mediaServiceController: MediaServiceController
-    private lateinit var topbarBackButton: ImageButton
-    private lateinit var topbarTitle: TextView
 
     companion object {
         private const val REQUEST_CODE_IMPORT_JSON = 1001
@@ -55,8 +50,6 @@ class StationsFragment : Fragment() {
     ): View {
         val view = inflater.inflate(R.layout.fragment_stations, container, false)
 
-        topbarBackButton = view.findViewById(R.id.arrow_back)
-        topbarTitle = view.findViewById(R.id.topbar_title)
 
         stationList = PreferencesHelper.getStations(requireContext()).toMutableList()
 
@@ -143,8 +136,10 @@ class StationsFragment : Fragment() {
         val parentPager = parentFragment?.view?.findViewById<ViewPager2>(R.id.main_view_pager)
         recyclerView.setOnTouchListener { _, event ->
             when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN -> parentPager?.requestDisallowInterceptTouchEvent(true)
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> parentPager?.requestDisallowInterceptTouchEvent(false)
+                MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE ->
+                    parentPager?.requestDisallowInterceptTouchEvent(true)
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+                    parentPager?.requestDisallowInterceptTouchEvent(false)
             }
             false
         }
@@ -171,10 +166,6 @@ class StationsFragment : Fragment() {
             startActivityForResult(intent, REQUEST_CODE_IMPORT_JSON)
         }
 
-        topbarBackButton.setOnClickListener {
-            refreshPlaylist()
-            (activity as? MainActivity)?.showPlayerPage()
-        }
 
         return view
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -146,7 +146,6 @@ class StationsFragment : Fragment() {
                     startX = event.x
                     startY = event.y
                     orientationDecided = false
-                    parentPager?.requestDisallowInterceptTouchEvent(true)
                 }
                 MotionEvent.ACTION_MOVE -> {
                     if (!orientationDecided) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -19,6 +19,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.MotionEvent
+import android.view.ViewConfiguration
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.adapter.StationListAdapter
@@ -32,6 +33,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.launch
 import java.util.*
+import kotlin.math.abs
 
 class StationsFragment : Fragment() {
 

--- a/app/src/main/res/layout/fragment_stations.xml
+++ b/app/src/main/res/layout/fragment_stations.xml
@@ -3,7 +3,6 @@
     android:padding="8dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <include layout="@layout/topbar" />
     <Button
         android:id="@+id/buttonAddStation"
         android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- allow nested scroll gestures in `StationsFragment`
- remove unused top bar from the stations layout

## Testing
- `sh ./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed2e40534832f97b344c61499bb14