### PR TITLE
Fix shortcut icon fallback

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
@@ -38,9 +38,12 @@ class ShortcutAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
         holder.labelTextView.text = item.label
+        val source = item.iconUrl.takeIf { it.isNotBlank() }
         Glide.with(holder.itemView)
-            .load(item.iconUrl)
+            .load(source)
             .placeholder(R.drawable.ic_placeholder_logo)
+            .error(R.drawable.ic_radio)
+            .fallback(R.drawable.ic_radio)
             .into(holder.iconImageView)
 
         holder.itemView.setOnClickListener { onClick(item) }


### PR DESCRIPTION
## Summary
- handle missing shortcut icons gracefully

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f261ce878832fad1679ac56e6dd0a