### PR TITLE
Fix shortcut list not updating after stream edits

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -64,7 +64,6 @@ class MediaServiceController(private val context: Context) {
 
                         if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && StateHelper.isPlaylistChangePending) {
                             onTimelineChanged(reason)
-                            StateHelper.isPlaylistChangePending = false
                         } else {
                             Log.d("MediaServiceController", "ℹ️ Timeline-Änderung ignoriert (Grund: $reason)")
                         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -31,6 +31,7 @@ import at.plankt0n.streamplay.adapter.ShortcutAdapter
 import at.plankt0n.streamplay.data.ShortcutItem
 import at.plankt0n.streamplay.helper.LiveCoverHelper
 import at.plankt0n.streamplay.helper.MediaServiceController
+import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
 import com.bumptech.glide.Glide
@@ -225,6 +226,14 @@ class PlayerFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         observeSpotifyTrackInfo()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (StateHelper.isPlaylistChangePending) {
+            reloadPlaylist()
+            StateHelper.isPlaylistChangePending = false
+        }
     }
 
     private fun observeSpotifyTrackInfo() {


### PR DESCRIPTION
## Summary
- refresh shortcuts when returning to the player if playlist changed

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2aa6b2c4832f812fedc5d035f30c