### PR TITLE
Implement minimize delay feature

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -271,24 +271,23 @@ class StreamingService : MediaSessionService() {
         val delay = prefs.getInt("autoplay_delay", 0)
         val minimize = prefs.getBoolean("minimize_after_autoplay", false)
 
-        val action = Runnable {
-            player.play()
-            if (minimize) {
+        player.play()
+
+        if (minimize) {
+            val action = Runnable {
                 sendBroadcast(Intent(Keys.ACTION_HIDE_COUNTDOWN))
                 minimizeApp()
             }
-        }
 
-        if (delay > 0) {
-            if (minimize) {
+            if (delay > 0) {
                 val intent = Intent(Keys.ACTION_SHOW_COUNTDOWN).apply {
                     putExtra(Keys.EXTRA_COUNTDOWN_DURATION, delay)
                 }
                 sendBroadcast(intent)
+                Handler(Looper.getMainLooper()).postDelayed(action, delay * 1000L)
+            } else {
+                action.run()
             }
-            Handler(Looper.getMainLooper()).postDelayed(action, delay * 1000L)
-        } else {
-            action.run()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,7 +99,7 @@
     <!-- Settings Fragment -->
     <string name="settings_title">Settings</string>
     <string name="settings_autoplay">Autoplay</string>
-    <string name="settings_delay">Autoplay Delay</string>
+    <string name="settings_delay">Minimize Delay</string>
     <string name="settings_delay_seconds">%1$d s</string>
     <string name="settings_minimize">Minimize after Autoplay</string>
     <string name="settings_category_playback">Playback</string>


### PR DESCRIPTION
## Summary
- rename setting label to "Minimize Delay"
- autoplay now always starts instantly and uses delay for minimizing only

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2add036c832f8c75ee600655abe4