### PR TITLE
Add crash logging handler

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
 
     <application
+    android:name=".StreamPlayApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,0 +1,11 @@
+package at.plankt0n.streamplay
+
+import android.app.Application
+import at.plankt0n.streamplay.helper.CrashHandler
+
+class StreamPlayApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this))
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CrashHandler.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CrashHandler.kt
@@ -1,0 +1,34 @@
+package at.plankt0n.streamplay.helper
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class CrashHandler(private val context: Context) : Thread.UncaughtExceptionHandler {
+    private val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+    override fun uncaughtException(t: Thread, e: Throwable) {
+        try {
+            val dir = File(context.getExternalFilesDir(null), "crashlogs")
+            if (!dir.exists()) dir.mkdirs()
+
+            val date = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+            val file = File(dir, "crash_" + date + ".txt")
+
+            val sw = StringWriter()
+            e.printStackTrace(PrintWriter(sw))
+            file.writeText(sw.toString())
+
+            Log.e("CrashHandler", "Crash-Log gespeichert: ${file.absolutePath}")
+        } catch (ex: Exception) {
+            Log.e("CrashHandler", "Fehler beim Schreiben des Crash-Logs", ex)
+        } finally {
+            defaultHandler?.uncaughtException(t, e)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- log uncaught exceptions to a file via `CrashHandler`
- introduce `StreamPlayApplication` and set it in the manifest
- update manifest to register the custom Application class

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fc15d30832f9073d3e95f17f253