### PR TITLE
Fix countdown intents in StreamingService

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -275,13 +275,14 @@ class StreamingService : MediaSessionService() {
 
         if (minimize) {
             val action = Runnable {
-                sendBroadcast(Intent(Keys.ACTION_HIDE_COUNTDOWN))
+                sendBroadcast(Intent(Keys.ACTION_HIDE_COUNTDOWN).setPackage(packageName))
                 minimizeApp()
             }
 
             if (delay > 0) {
                 val intent = Intent(Keys.ACTION_SHOW_COUNTDOWN).apply {
                     putExtra(Keys.EXTRA_COUNTDOWN_DURATION, delay)
+                    setPackage(packageName)
                 }
                 sendBroadcast(intent)
                 Handler(Looper.getMainLooper()).postDelayed(action, delay * 1000L)


### PR DESCRIPTION
## Summary
- ensure countdown broadcast intents target the app package

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fcc8f90832f97984213ad199775