### PR TITLE
Show station icons in station list

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import com.bumptech.glide.Glide
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
@@ -64,6 +65,13 @@ class StationListAdapter(
 
         holder.playButton.visibility = if (isEditing) View.GONE else View.VISIBLE
         holder.playButton.setOnClickListener { onPlayClick(position) }
+
+        Glide.with(holder.playButton.context)
+            .load(station.iconURL)
+            .placeholder(R.drawable.ic_stationcover_placeholder)
+            .error(R.drawable.ic_stationcover_placeholder)
+            .fallback(R.drawable.ic_stationcover_placeholder)
+            .into(holder.playButton)
 
         val context = holder.itemView.context
         if (position == currentPlayingIndex) {

--- a/app/src/main/res/layout/item_station_editable.xml
+++ b/app/src/main/res/layout/item_station_editable.xml
@@ -18,9 +18,10 @@
             android:layout_height="40dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/desc_button_play_station"
-            android:src="@drawable/ic_button_play"
+            android:src="@drawable/ic_stationcover_placeholder"
             android:layout_alignParentStart="true"
-            android:layout_centerVertical="true" />
+            android:layout_centerVertical="true"
+            android:scaleType="centerCrop" />
 
         <LinearLayout
             android:id="@+id/stationTexts"


### PR DESCRIPTION
## Summary
- load station icons with Glide in `StationListAdapter`
- display a placeholder icon in `item_station_editable.xml`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3035ace0832fb5b490394b26a279