### PR TITLE
Handle missing metadata text

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -444,6 +444,9 @@ class StreamingService : MediaSessionService() {
             Log.d("StreamingService", "App im Vordergrund: bleibt so")
         } else {
             updatetitle = "$artist - $title"
+            if (artist.isBlank() && title.isBlank()) {
+                updatetitle = getString(R.string.no_metadata_available)
+            }
             updateartist = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "Sendername nicht Gesetzt"
             Log.d("StreamingService", "App ist im Hinterrgund: updateartist=$updateartist, updatetitle=$updatetitle")
         }
@@ -487,6 +490,9 @@ val title = refreshMetaData?.title?.toString().orEmpty()
             Log.d("StreamingService", "App im Vordergrund: bleibt so")
         } else {
             updatetitle = "$artist - $title"
+            if (artist.isBlank() && title.isBlank()) {
+                updatetitle = getString(R.string.no_metadata_available)
+            }
             updateartist = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "Sendername nicht Gesetzt"
             Log.d("StreamingService", "App ist im Hinterrgund: updateartist=$updateartist, updatetitle=$updatetitle")
         }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -436,7 +436,7 @@ class StreamingService : MediaSessionService() {
         lastArtworkUri = artworkUri
 
         val updateartist: String
-        val updatetitle: String
+        var updatetitle: String
 
         if (isInForeground) {
             updateartist = artist
@@ -479,7 +479,7 @@ class StreamingService : MediaSessionService() {
 
 
         val updateartist: String
-        val updatetitle: String
+        var updatetitle: String
 val artist = refreshMetaData?.artist?.toString().orEmpty()
 val title = refreshMetaData?.title?.toString().orEmpty()
         val artworkUri = refreshMetaData?.artworkUri?.toString().orEmpty()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,5 @@
     <string name="settings_category_ui">UI Settings</string>
     <string name="settings_category_metainfo">Metainfo Settings</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
+    <string name="no_metadata_available">Keine Informationen verfügbar</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `no_metadata_available` string resource
- show placeholder when artist and title are both blank when updating metadata

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d91840530832f93de4e7b894670c6