### PR TITLE
Fix crash when no stations exist

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/MainPagerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/MainPagerFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.R
 
 class MainPagerFragment : Fragment() {
@@ -25,12 +26,17 @@ class MainPagerFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         viewPager = view.findViewById(R.id.main_view_pager)
         viewPager.orientation = ViewPager2.ORIENTATION_VERTICAL
-        viewPager.adapter = object : FragmentStateAdapter(this) {
+        val adapter = object : FragmentStateAdapter(this) {
             override fun getItemCount(): Int = 2
             override fun createFragment(position: Int): Fragment = when (position) {
                 0 -> PlayerFragment()
                 else -> StationsFragment()
             }
+        }
+        viewPager.adapter = adapter
+
+        if (PreferencesHelper.getStations(requireContext()).isEmpty()) {
+            viewPager.setCurrentItem(1, false)
         }
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -32,6 +32,7 @@ import at.plankt0n.streamplay.data.ShortcutItem
 import at.plankt0n.streamplay.helper.LiveCoverHelper
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.StateHelper
+import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
 import com.bumptech.glide.Glide
@@ -82,6 +83,12 @@ class PlayerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (PreferencesHelper.getStations(requireContext()).isEmpty()) {
+            Log.w("PlayerFragment", "\u26a0\ufe0f Keine Stationen gespeichert, Wechsel ins StationsFragment.")
+            (activity as? MainActivity)?.showStationsPage()
+            return
+        }
 
         buttonMenu = view.findViewById(R.id.button_menu)
         viewPager = view.findViewById(R.id.view_pager)
@@ -341,6 +348,12 @@ class PlayerFragment : Fragment() {
 
     private fun reloadPlaylist() {
         val controller = mediaServiceController.mediaController ?: return
+
+        if (controller.mediaItemCount == 0) {
+            Log.w("PlayerFragment", "\u26a0\ufe0f Playlist leer nach Reload. Wechsel ins StationsFragment.")
+            (activity as? MainActivity)?.showStationsPage()
+            return
+        }
 
         val shortcuts = (0 until controller.mediaItemCount).mapNotNull { i ->
             val mediaItem = controller.getMediaItemAt(i)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -86,13 +86,15 @@ class PlayerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        buttonMenu = view.findViewById(R.id.button_menu)
+        buttonMenu.setOnClickListener { showBottomSheet() }
+
         if (PreferencesHelper.getStations(requireContext()).isEmpty()) {
             Log.w("PlayerFragment", "\u26a0\ufe0f Keine Stationen gespeichert, Wechsel ins StationsFragment.")
             (activity as? MainActivity)?.showStationsPage()
             return
         }
 
-        buttonMenu = view.findViewById(R.id.button_menu)
         viewPager = view.findViewById(R.id.view_pager)
         viewPager.offscreenPageLimit = 2
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -41,6 +41,8 @@ import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
 
 class PlayerFragment : Fragment() {
 
+    private var initialized = false
+
     private lateinit var viewPager: ViewPager2
     private lateinit var dotsIndicator: WormDotsIndicator
     private lateinit var mediaServiceController: MediaServiceController
@@ -228,15 +230,18 @@ class PlayerFragment : Fragment() {
             }
             isMuted = !isMuted
         }
+        initialized = true
     }
 
     override fun onStart() {
         super.onStart()
+        if (!initialized) return
         observeSpotifyTrackInfo()
     }
 
     override fun onResume() {
         super.onResume()
+        if (!initialized) return
         if (StateHelper.isPlaylistChangePending) {
             reloadPlaylist()
             StateHelper.isPlaylistChangePending = false
@@ -379,10 +384,12 @@ class PlayerFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        if (initialized) {
+            requireContext().unregisterReceiver(autoplayReceiver)
+            countdownHandler.removeCallbacksAndMessages(null)
+            mediaServiceController.disconnect()
+        }
         super.onDestroyView()
-        requireContext().unregisterReceiver(autoplayReceiver)
-        countdownHandler.removeCallbacksAndMessages(null)
-        mediaServiceController.disconnect()
     }
 
     private fun showBottomSheet() {


### PR DESCRIPTION
## Summary
- avoid initializing the player when there are no saved stations
- show the stations screen if playlist is empty after reload

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee34d4510832fa4b71772b6fc33be