### PR TITLE
Fix playlist refresh after importing stations

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -278,6 +278,7 @@ class StationsFragment : Fragment() {
 
             PreferencesHelper.saveStations(requireContext(), stationList)
             adapter.notifyDataSetChanged()
+            refreshPlaylist()
 
             Toast.makeText(requireContext(), "Import abgeschlossen: $added neu, $updated aktualisiert.", Toast.LENGTH_LONG).show()
 


### PR DESCRIPTION
## Summary
- refresh playlist when stations are imported

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee936eeb4832f84fd7607cfaf7c33