### PR TITLE
Open Discover when stations missing

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/helper/StateHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/StateHelper.kt
@@ -2,4 +2,5 @@ package at.plankt0n.streamplay.helper
 
 object StateHelper {
     var isPlaylistChangePending: Boolean = false
+    var hasAutoOpenedDiscover: Boolean = false
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -129,8 +129,15 @@ class PlayerFragment : Fragment() {
                 shortcutAdapter.setItems(shortcuts)
 
                 if (controller.mediaItemCount == 0) {
-                    Log.w("PlayerFragment", "\u26a0\ufe0f MediaSession ist leer! Wechsel ins StationsFragment.")
-                    (activity as? MainActivity)?.showStationsPage()
+                    Log.w(
+                        "PlayerFragment",
+                        "\u26a0\ufe0f MediaSession ist leer! Öffne DiscoverFragment."
+                    )
+                    parentFragmentManager.beginTransaction()
+                        .setReorderingAllowed(true)
+                        .replace(R.id.fragment_container, DiscoverFragment())
+                        .addToBackStack(null)
+                        .commit()
                     return@initializeAndConnect
                 }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -133,7 +133,7 @@ class PlayerFragment : Fragment() {
                         "PlayerFragment",
                         "\u26a0\ufe0f MediaSession ist leer! Öffne DiscoverFragment."
                     )
-                    parentFragmentManager.beginTransaction()
+                    requireActivity().supportFragmentManager.beginTransaction()
                         .setReorderingAllowed(true)
                         .replace(R.id.fragment_container, DiscoverFragment())
                         .addToBackStack(null)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -129,16 +129,22 @@ class PlayerFragment : Fragment() {
                 shortcutAdapter.setItems(shortcuts)
 
                 if (controller.mediaItemCount == 0) {
-                    Log.w(
-                        "PlayerFragment",
-                        "\u26a0\ufe0f MediaSession ist leer! Öffne DiscoverFragment."
-                    )
-                    requireActivity().supportFragmentManager.beginTransaction()
-                        .setReorderingAllowed(true)
-                        .replace(R.id.fragment_container, DiscoverFragment())
-                        .addToBackStack(null)
-                        .commit()
+                    if (!StateHelper.hasAutoOpenedDiscover) {
+                        Log.w(
+                            "PlayerFragment",
+                            "\u26a0\ufe0f MediaSession ist leer! Öffne DiscoverFragment."
+                        )
+                        StateHelper.hasAutoOpenedDiscover = true
+                        requireActivity().supportFragmentManager
+                            .beginTransaction()
+                            .setReorderingAllowed(true)
+                            .replace(R.id.fragment_container, DiscoverFragment())
+                            .addToBackStack(null)
+                            .commit()
+                    }
                     return@initializeAndConnect
+                } else {
+                    StateHelper.hasAutoOpenedDiscover = false
                 }
 
                 val coverPageAdapter = CoverPageAdapter(mediaServiceController)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -106,6 +106,12 @@ class PlayerFragment : Fragment() {
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
 
+        // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
+        playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
+        buttonBack.setOnClickListener { mediaServiceController.skipToPrevious() }
+        buttonForward.setOnClickListener { mediaServiceController.skipToNext() }
+        buttonMenu.setOnClickListener { showBottomSheet() }
+
         val filter = IntentFilter().apply {
             addAction(Keys.ACTION_SHOW_COUNTDOWN)
             addAction(Keys.ACTION_HIDE_COUNTDOWN)
@@ -169,10 +175,6 @@ class PlayerFragment : Fragment() {
                     }
                 })
 
-                playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
-                buttonBack.setOnClickListener { mediaServiceController.skipToPrevious() }
-                buttonForward.setOnClickListener { mediaServiceController.skipToNext() }
-                buttonMenu.setOnClickListener { showBottomSheet() }
             },
             onPlaybackChanged = { updatePlayPauseIcon(it) },
             onStreamIndexChanged = { index ->


### PR DESCRIPTION
## Summary
- handle empty playlist when the app starts
- open `DiscoverFragment` instead of Stations page if no stations are loaded

## Testing
- `./gradlew tasks --all | head` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eecf14940832f85b9806d0672e419