### PR TITLE
Ensure topbar back arrow works in discover screen

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/DiscoverFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/DiscoverFragment.kt
@@ -29,6 +29,7 @@ class DiscoverFragment : Fragment() {
     private lateinit var adapter: DiscoverAdapter
     private lateinit var searchField: EditText
     private lateinit var searchButton: ImageButton
+    private lateinit var backButton: ImageButton
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -42,6 +43,11 @@ class DiscoverFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         searchField = view.findViewById(R.id.editSearchRadio)
         searchButton = view.findViewById(R.id.buttonSearchRadio)
+        backButton = view.findViewById(R.id.arrow_back)
+
+        backButton.setOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
 
         adapter = DiscoverAdapter(stations) { station ->
             android.app.AlertDialog.Builder(requireContext())


### PR DESCRIPTION
## Summary
- connect the topbar back arrow in `DiscoverFragment`

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a648b74832fa78a66fd6c12c84d