### PR TITLE
Implement GitHub update checker

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/helper/GitHubUpdateChecker.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/GitHubUpdateChecker.kt
@@ -1,0 +1,149 @@
+package at.plankt0n.streamplay.helper
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import at.plankt0n.streamplay.BuildConfig
+import at.plankt0n.streamplay.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.io.File
+
+class GitHubUpdateChecker(private val context: Context) {
+
+    private val client = OkHttpClient()
+    private val apiUrl = "https://api.github.com/repos/Planqton/streamplay/releases/latest"
+
+    suspend fun checkForUpdate() {
+        val progress = withContext(Dispatchers.Main) {
+            val bar = ProgressBar(context)
+            AlertDialog.Builder(context)
+                .setTitle(context.getString(R.string.update_checking))
+                .setView(bar)
+                .setCancelable(false)
+                .show()
+        }
+
+        try {
+            val request = Request.Builder().url(apiUrl).build()
+            val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+            val bodyStr = response.body?.string()
+            if (!response.isSuccessful || bodyStr.isNullOrEmpty()) {
+                throw Exception("HTTP ${'$'}{response.code}")
+            }
+            val json = JSONObject(bodyStr)
+            val remoteVersion = json.getString("tag_name").removePrefix("v")
+            var apkUrl: String? = null
+            val assets = json.optJSONArray("assets")
+            if (assets != null) {
+                for (i in 0 until assets.length()) {
+                    val obj = assets.getJSONObject(i)
+                    if (obj.optString("name").endsWith(".apk")) {
+                        apkUrl = obj.optString("browser_download_url")
+                        break
+                    }
+                }
+            }
+            val localVersion = BuildConfig.VERSION_NAME
+            withContext(Dispatchers.Main) { progress.dismiss() }
+            if (isNewerVersion(remoteVersion, localVersion) && !apkUrl.isNullOrEmpty()) {
+                withContext(Dispatchers.Main) {
+                    AlertDialog.Builder(context)
+                        .setTitle(context.getString(R.string.update_available_title))
+                        .setMessage(context.getString(R.string.update_available_message, remoteVersion))
+                        .setPositiveButton(android.R.string.ok) { _, _ ->
+                            CoroutineScope(Dispatchers.Main).launch { downloadAndInstall(apkUrl!!) }
+                        }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show()
+                }
+            } else {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, context.getString(R.string.update_latest), Toast.LENGTH_SHORT).show()
+                }
+            }
+        } catch (_: Exception) {
+            withContext(Dispatchers.Main) {
+                progress.dismiss()
+                Toast.makeText(context, context.getString(R.string.update_check_fail), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun isNewerVersion(remote: String, local: String): Boolean {
+        val r = remote.split('.')
+        val l = local.split('.')
+        val max = maxOf(r.size, l.size)
+        for (i in 0 until max) {
+            val rv = r.getOrNull(i)?.toIntOrNull() ?: 0
+            val lv = l.getOrNull(i)?.toIntOrNull() ?: 0
+            if (rv > lv) return true
+            if (rv < lv) return false
+        }
+        return false
+    }
+
+    private suspend fun downloadAndInstall(url: String) {
+        val (dialog, bar) = withContext(Dispatchers.Main) {
+            val progress = ProgressBar(context, null, android.R.attr.progressBarStyleHorizontal).apply { max = 100 }
+            val dlg = AlertDialog.Builder(context)
+                .setTitle(context.getString(R.string.update_downloading))
+                .setView(progress)
+                .setCancelable(false)
+                .create()
+            dlg.show()
+            dlg to progress
+        }
+
+        try {
+            val request = Request.Builder().url(url).build()
+            val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+            val body = response.body ?: throw Exception("no body")
+            val file = File(context.getExternalFilesDir(null), "update.apk")
+            withContext(Dispatchers.IO) {
+                val total = body.contentLength()
+                var read = 0L
+                body.byteStream().use { input ->
+                    file.outputStream().use { output ->
+                        val buffer = ByteArray(8 * 1024)
+                        var bytes = input.read(buffer)
+                        while (bytes >= 0) {
+                            if (bytes > 0) {
+                                output.write(buffer, 0, bytes)
+                                read += bytes
+                                if (total > 0) {
+                                    val progressValue = (read * 100 / total).toInt()
+                                    withContext(Dispatchers.Main) { bar.progress = progressValue }
+                                }
+                            }
+                            bytes = input.read(buffer)
+                        }
+                    }
+                }
+            }
+            val uri = FileProvider.getUriForFile(context, context.packageName + ".provider", file)
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, "application/vnd.android.package-archive")
+                flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            withContext(Dispatchers.Main) {
+                dialog.dismiss()
+                context.startActivity(intent)
+            }
+        } catch (_: Exception) {
+            withContext(Dispatchers.Main) {
+                dialog.dismiss()
+                Toast.makeText(context, context.getString(R.string.update_download_fail), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
@@ -1,22 +1,12 @@
 package at.plankt0n.streamplay.ui
 
 import android.os.Bundle
-import android.widget.ProgressBar
-import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import at.plankt0n.streamplay.Keys
-import at.plankt0n.streamplay.R
-import kotlinx.coroutines.Dispatchers
+import at.plankt0n.streamplay.helper.GitHubUpdateChecker
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import org.json.JSONObject
-import androidx.core.content.FileProvider
-import android.content.Intent
-import java.io.File
 
 class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -24,129 +14,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
         initSettingsScreen()
 
         findPreference<Preference>("check_updates")?.setOnPreferenceClickListener {
-            lifecycleScope.launch { checkForUpdates() }
+            lifecycleScope.launch {
+                GitHubUpdateChecker(requireContext()).checkForUpdate()
+            }
             true
         }
     }
 
-    private suspend fun checkForUpdates() {
-        val progress = withContext(Dispatchers.Main) {
-            val bar = ProgressBar(requireContext())
-            android.app.AlertDialog.Builder(requireContext())
-                .setTitle(getString(R.string.update_checking))
-                .setView(bar)
-                .setCancelable(false)
-                .show()
-        }
-
-        withContext(Dispatchers.IO) {
-            try {
-                val client = OkHttpClient()
-                val request = Request.Builder()
-                    .url(Keys.PREFS_UPDATE_URL)
-                    .build()
-                client.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) throw Exception("http ${'$'}{response.code}")
-                    val json = JSONObject(response.body?.string() ?: "")
-                    val remoteVersion = json.getString("version")
-                    val apkUrl = json.getString("apkUrl")
-                    val pkgInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
-                    val localVersion = pkgInfo.versionName ?: ""
-                    withContext(Dispatchers.Main) { progress.dismiss() }
-                    if (isNewerVersion(remoteVersion, localVersion)) {
-                        withContext(Dispatchers.Main) {
-                            android.app.AlertDialog.Builder(requireContext())
-                                .setTitle(getString(R.string.update_available_title))
-                                .setMessage(getString(R.string.update_available_message, remoteVersion))
-                                .setPositiveButton(android.R.string.ok) { _, _ ->
-                                    lifecycleScope.launch { downloadAndInstall(apkUrl) }
-                                }
-                                .setNegativeButton(android.R.string.cancel, null)
-                                .show()
-                        }
-                    } else {
-                        withContext(Dispatchers.Main) {
-                            Toast.makeText(requireContext(), getString(R.string.update_latest), Toast.LENGTH_SHORT).show()
-                        }
-                    }
-                }
-            } catch (_: Exception) {
-                withContext(Dispatchers.Main) {
-                    progress.dismiss()
-                    Toast.makeText(requireContext(), getString(R.string.update_check_fail), Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
-    }
-
-    private fun isNewerVersion(remote: String, local: String): Boolean {
-        val r = remote.split('.').map { it.toIntOrNull() ?: 0 }
-        val l = local.split('.').map { it.toIntOrNull() ?: 0 }
-        val maxLen = maxOf(r.size, l.size)
-        for (i in 0 until maxLen) {
-            val rv = r.getOrElse(i) { 0 }
-            val lv = l.getOrElse(i) { 0 }
-            if (rv > lv) return true
-            if (rv < lv) return false
-        }
-        return false
-    }
-
-    private suspend fun downloadAndInstall(url: String) {
-        val (dialog, bar) = withContext(Dispatchers.Main) {
-            val progress = ProgressBar(requireContext(), null, android.R.attr.progressBarStyleHorizontal).apply { max = 100 }
-            val dlg = android.app.AlertDialog.Builder(requireContext())
-                .setTitle(getString(R.string.update_downloading))
-                .setView(progress)
-                .setCancelable(false)
-                .create()
-            dlg.show()
-            dlg to progress
-        }
-
-        withContext(Dispatchers.IO) {
-            try {
-                val client = OkHttpClient()
-                val request = Request.Builder().url(url).build()
-                val file = File(requireContext().getExternalFilesDir(null), "update.apk")
-                client.newCall(request).execute().use { resp ->
-                    val body = resp.body ?: throw Exception("no body")
-                    val total = body.contentLength()
-                    var read = 0L
-                    body.byteStream().use { input ->
-                        file.outputStream().use { output ->
-                            val buffer = ByteArray(8 * 1024)
-                            var bytes = input.read(buffer)
-                            while (bytes >= 0) {
-                                if (bytes > 0) {
-                                    output.write(buffer, 0, bytes)
-                                    read += bytes
-                                    if (total > 0) {
-                                        val progress = (read * 100 / total).toInt()
-                                        withContext(Dispatchers.Main) { bar.progress = progress }
-                                    }
-                                }
-                                bytes = input.read(buffer)
-                            }
-                        }
-                    }
-                }
-
-                val uri = FileProvider.getUriForFile(requireContext(), requireContext().packageName + ".provider", file)
-                val intent = Intent(Intent.ACTION_VIEW).apply {
-                    setDataAndType(uri, "application/vnd.android.package-archive")
-                    flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK
-                }
-                withContext(Dispatchers.Main) {
-                    dialog.dismiss()
-                    startActivity(intent)
-                }
-            } catch (_: Exception) {
-                withContext(Dispatchers.Main) {
-                    dialog.dismiss()
-                    Toast.makeText(requireContext(), getString(R.string.update_download_fail), Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add new `GitHubUpdateChecker` helper to check GitHub releases
- simplify `SettingsFragment` to use the new helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860298371c0832f9bf9c8418c4e4b00