### PR TITLE
Add metadata logging with viewer

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -17,6 +17,9 @@ object Keys {
     const val KEY_SPOTIFY_CLIENT_ID = "cc55a94b922c496a84c4a725242a313b"
     const val KEY_SPOTIFY_CLIENT_SECRET = "1893b26ecec74a4984152f0d86200b63"
 
+    const val KEY_META_LOGS_PREFS = "meta_log_prefs"
+    const val KEY_META_LOGS = "metadata_logs"
+
 
     // mime types and charsets and file extensions
     const val CHARSET_UNDEFINDED = "undefined"

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -38,6 +38,8 @@ import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.IcyStreamReader
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.SpotifyMetaReader
+import at.plankt0n.streamplay.helper.MetaLogHelper
+import at.plankt0n.streamplay.data.MetaLogEntry
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.viewmodel.UITrackInfo
 import kotlinx.coroutines.Dispatchers
@@ -393,7 +395,18 @@ class StreamingService : MediaSessionService() {
                             title = extendedInfo.trackName,
                             artist = extendedInfo.artistName,
                             artworkUri = extendedInfo.bestCoverUrl ?: ""
+                        )
+                        )
 
+                        MetaLogHelper.addLog(
+                            this@StreamingService,
+                            MetaLogEntry(
+                                timestamp = System.currentTimeMillis(),
+                                station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                                title = extendedInfo.trackName,
+                                artist = extendedInfo.artistName,
+                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() }
+                            )
                         )
                     } else {
                         Log.w(
@@ -406,6 +419,16 @@ class StreamingService : MediaSessionService() {
                                 trackName = title,
                                 artistName = artist,
                                 bestCoverUrl = fallbackartworkUri
+                            )
+                        )
+                        MetaLogHelper.addLog(
+                            this@StreamingService,
+                            MetaLogEntry(
+                                timestamp = System.currentTimeMillis(),
+                                station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                                title = title,
+                                artist = artist,
+                                url = null
                             )
                         )
                     }
@@ -425,6 +448,16 @@ class StreamingService : MediaSessionService() {
                     trackName = title,
                     artistName = artist,
                     bestCoverUrl = fallbackartworkUri
+                )
+            )
+            MetaLogHelper.addLog(
+                this@StreamingService,
+                MetaLogEntry(
+                    timestamp = System.currentTimeMillis(),
+                    station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                    title = title,
+                    artist = artist,
+                    url = null
                 )
             )
         }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
@@ -1,0 +1,49 @@
+package at.plankt0n.streamplay.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.data.MetaLogEntry
+
+class MetaLogAdapter(
+    private val onUrlClick: (String) -> Unit
+) : RecyclerView.Adapter<MetaLogAdapter.ViewHolder>() {
+
+    private val items = mutableListOf<MetaLogEntry>()
+
+    fun setItems(newItems: List<MetaLogEntry>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val line1: TextView = view.findViewById(R.id.log_line1)
+        val line2: TextView = view.findViewById(R.id.log_line2)
+        val button: ImageButton = view.findViewById(R.id.log_open_button)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_meta_log, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        holder.line1.text = "${item.formattedTime()} - ${item.station}"
+        holder.line2.text = "${item.title} - ${item.artist}"
+        if (!item.url.isNullOrBlank()) {
+            holder.button.visibility = View.VISIBLE
+            holder.button.setOnClickListener { onUrlClick(item.url!!) }
+        } else {
+            holder.button.visibility = View.GONE
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
@@ -1,0 +1,18 @@
+package at.plankt0n.streamplay.data
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+data class MetaLogEntry(
+    val timestamp: Long,
+    val station: String,
+    val title: String,
+    val artist: String,
+    val url: String? = null
+) {
+    fun formattedTime(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        return sdf.format(Date(timestamp))
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
@@ -1,0 +1,34 @@
+package at.plankt0n.streamplay.helper
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import at.plankt0n.streamplay.data.MetaLogEntry
+import at.plankt0n.streamplay.Keys
+
+object MetaLogHelper {
+    private const val PREFS_NAME = Keys.KEY_META_LOGS_PREFS
+    private const val KEY_LOGS = Keys.KEY_META_LOGS
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun addLog(context: Context, entry: MetaLogEntry) {
+        val list = getLogs(context)
+        list.add(0, entry) // newest first
+        val json = Gson().toJson(list)
+        prefs(context).edit().putString(KEY_LOGS, json).apply()
+    }
+
+    fun getLogs(context: Context): MutableList<MetaLogEntry> {
+        val json = prefs(context).getString(KEY_LOGS, null)
+        return if (json != null) {
+            val type = object : TypeToken<MutableList<MetaLogEntry>>() {}.type
+            Gson().fromJson(json, type)
+        } else mutableListOf()
+    }
+
+    fun clear(context: Context) {
+        prefs(context).edit().remove(KEY_LOGS).apply()
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
@@ -14,6 +14,7 @@ import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.ui.DiscoverFragment
 import at.plankt0n.streamplay.MainActivity
 import at.plankt0n.streamplay.ui.SettingsFragment
+import at.plankt0n.streamplay.ui.MetaLogFragment
 import at.plankt0n.streamplay.Keys
 
 class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
@@ -55,6 +56,11 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
             openDiscoverFragment()
         }
 
+        view.findViewById<LinearLayout>(R.id.option_logs).setOnClickListener {
+            dismiss()
+            openMetaLogFragment()
+        }
+
         // Inflate settings fragment into this sheet
         if (savedInstanceState == null) {
             childFragmentManager.beginTransaction()
@@ -85,6 +91,14 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
         requireActivity().supportFragmentManager.beginTransaction()
             .setReorderingAllowed(true)
             .replace(R.id.fragment_container, DiscoverFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    private fun openMetaLogFragment() {
+        requireActivity().supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .replace(R.id.fragment_container, MetaLogFragment())
             .addToBackStack(null)
             .commit()
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
@@ -1,0 +1,54 @@
+package at.plankt0n.streamplay.ui
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageButton
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.adapter.MetaLogAdapter
+import at.plankt0n.streamplay.helper.MetaLogHelper
+
+class MetaLogFragment : Fragment() {
+    private lateinit var adapter: MetaLogAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_meta_log, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val backButton = view.findViewById<ImageButton>(R.id.arrow_back)
+        backButton.setOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+
+        adapter = MetaLogAdapter { url ->
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            startActivity(intent)
+        }
+        val recycler = view.findViewById<RecyclerView>(R.id.recyclerMetaLog)
+        recycler.layoutManager = LinearLayoutManager(requireContext())
+        recycler.adapter = adapter
+
+        view.findViewById<Button>(R.id.buttonClearLogs).setOnClickListener {
+            MetaLogHelper.clear(requireContext())
+            adapter.setItems(emptyList())
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        adapter.setItems(MetaLogHelper.getLogs(requireContext()))
+    }
+}

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -78,6 +78,32 @@
             android:textAppearance="?attr/textAppearanceBody1" />
     </LinearLayout>
 
+    <!-- Eintrag: Logs anzeigen -->
+    <LinearLayout
+        android:id="@+id/option_logs"
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp"
+        android:clickable="true"
+        android:foreground="?attr/selectableItemBackground">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_button_manuallog"
+            android:contentDescription="@string/bottom_sheet_logs_content_desc"
+            android:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="16dp"
+            android:text="@string/bottom_sheet_logs_text"
+            android:textAppearance="?attr/textAppearanceBody1" />
+    </LinearLayout>
+
     <!-- Eintrag 3: Abstandhalter -->
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_meta_log.xml
+++ b/app/src/main/res/layout/fragment_meta_log.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/topbar" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerMetaLog"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/buttonClearLogs"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Clear Logs" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_meta_log.xml
+++ b/app/src/main/res/layout/item_meta_log.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/log_line1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="time - station"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/log_line2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="title - artist" />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/log_open_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_button_spotify"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/desc_button_manual_log" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <!-- Option Discover -->
     <string name="bottom_sheet_discover_text">Discover Stations</string>
     <string name="bottom_sheet_discover_content_desc">Browse online stations</string>
+    <string name="bottom_sheet_logs_text">Show Logs</string>
+    <string name="bottom_sheet_logs_content_desc">View metadata log</string>
 
     <string name="drag_handle_desc">Move station</string>
 


### PR DESCRIPTION
## Summary
- track metadata changes via new `MetaLogHelper`
- show and clear logs in new `MetaLogFragment`
- allow opening logged URLs
- add "Show Logs" option to bottom sheet

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603caddef8832fa624ffac2547bf53