### PR TITLE
Fix text contrast

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,8 +24,8 @@
 
         <!-- Schriftfarben -->
 
-        <item name="android:textColor">@color/primary_dark_material_light</item>
-        <item name="android:textColorSecondary">@color/primary_dark_material_light</item>
+        <item name="android:textColor">@color/textPrimary</item>
+        <item name="android:textColorSecondary">@color/textSecondary</item>
         <item name="preferenceCategoryStyle">@style/PreferenceCategory.WhiteText</item>
         <!-- Divider / Trennlinien -->
         <item name="dividerColor">@color/divider</item>


### PR DESCRIPTION
## Summary
- improve readability in dark theme by setting primary text colors

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686044a0fd54832fb6bfc7e68e7f596b