### PR TITLE
Restrict landscape layout to sw360dp

### DIFF
--- a/app/src/main/res/layout-sw360dp-land/fragment_player.xml
+++ b/app/src/main/res/layout-sw360dp-land/fragment_player.xml
@@ -1,0 +1,24 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fragment_player"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- ViewPager2 für Hintergrund/Cover -->
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!-- WormDotsIndicator -->
+    <com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
+        android:id="@+id/dots_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginBottom="16dp" />
+
+    <!-- Fixiertes UI Overlay -->
+    <include layout="@layout/fragment_player_ui_overlay" />
+
+</FrameLayout>

--- a/app/src/main/res/layout-sw360dp-land/fragment_player_coverpagview.xml
+++ b/app/src/main/res/layout-sw360dp-land/fragment_player_coverpagview.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/media_item_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:contentDescription="@string/desc_media_item_container">
+
+    <!-- Guidelines -->
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_middle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5"
+        android:contentDescription="@string/desc_guideline" />
+
+    <!-- Cover Image -->
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/cover_image"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="40dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_placeholder_logo"
+        android:contentDescription="@string/desc_cover_image"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerFamilyRounded"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintBottom_toTopOf="@id/guideline_middle" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw360dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw360dp-land/fragment_player_ui_overlay.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/media_item_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:contentDescription="@string/desc_media_item_container">
+
+    <!-- Guidelines -->
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_middle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5"
+        android:contentDescription="@string/desc_guideline" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_upperGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/desc_guideline"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.65" />
+
+    <TextView
+        android:id="@+id/autoplay_countdown"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:padding="8dp"
+        android:textColor="@android:color/black"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- Player Buttons -->
+    <LinearLayout
+        android:id="@+id/player_buttons_group"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:contentDescription="@string/desc_player_buttons_group"
+        android:background="@android:color/transparent"
+        app:layout_constraintTop_toBottomOf="@id/guideline_middle"
+        app:layout_constraintBottom_toTopOf="@id/guideline_upperGroup"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageButton
+            android:id="@+id/button_back"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_button_back"
+            android:src="@drawable/ic_button_back"
+            app:tint="@color/primary_material_light" />
+
+        <ImageButton
+            android:id="@+id/button_play_pause"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_button_play_pause"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_button_play"
+            app:tint="@color/primary_material_light" />
+
+        <ImageButton
+            android:id="@+id/button_forward"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_button_forward"
+            android:src="@drawable/ic_button_forward"
+            app:tint="@color/primary_material_light" />
+    </LinearLayout>
+
+    <!-- Station Info Overlay -->
+    <FrameLayout
+        android:id="@+id/station_overlay_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="100dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:clipToOutline="true"
+        android:elevation="4dp"
+        android:contentDescription="@string/desc_station_overlay_container"
+        app:layout_constraintTop_toTopOf="@id/guideline_upperGroup"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/right_buttons_container">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="4dp">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/station_overlay_stationIcon"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:background="@drawable/rounded_background_coverimage"
+                android:contentDescription="@string/desc_station_overlay_image"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_placeholder_logo"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerFamilyRounded" />
+
+            <TextView
+                android:id="@+id/station_overlay_stationname"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/unknown_station"
+                android:textSize="12sp"
+                android:textColor="@color/primary_text_default_material_dark"/>
+        </LinearLayout>
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/right_buttons_container"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginStart="100dp"
+        android:layout_marginEnd="100dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:clipToOutline="true"
+        android:elevation="4dp"
+        android:contentDescription="@string/desc_right_buttons_container"
+        app:layout_constraintTop_toTopOf="@id/guideline_upperGroup"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/metainfo_overlay_container">
+
+
+    <LinearLayout
+            android:id="@+id/right_vertical_buttons"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="8dp">
+
+            <ImageButton
+                android:id="@+id/button_mute_unmute"
+                android:layout_width="24dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="0dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_button_unmuted"
+                android:contentDescription="@string/desc_button_mute_unmute"
+                app:tint="@color/primary_dark_material_dark" />
+
+            <ImageButton
+                android:id="@+id/button_share"
+                android:layout_width="24dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="0dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_button_share"
+                android:contentDescription="@string/desc_button_share"
+                app:tint="@color/primary_dark_material_dark" />
+
+            <ImageButton
+                android:id="@+id/button_menu"
+                android:layout_width="24dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="0dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_button_menu"
+                android:contentDescription="@string/desc_button_menu"
+                app:tint="@color/primary_dark_material_dark" />
+        </LinearLayout>
+    </FrameLayout>
+
+    <!-- Wrapper um den Shortcut RecyclerView -->
+    <FrameLayout
+        android:id="@+id/shortcut_recycler_wrapper"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="100dp"
+        android:layout_marginEnd="100dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@android:color/transparent"
+        app:layout_constraintTop_toBottomOf="@id/station_overlay_container"
+        app:layout_constraintBottom_toTopOf="@id/metainfo_overlay_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/right_buttons_container">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/shortcut_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:contentDescription="@string/desc_shortcut_recycler_view"
+            android:overScrollMode="never"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            tools:listitem="@layout/shortcut_item" />
+    </FrameLayout>
+
+    <!-- MetaInfo Overlay -->
+    <FrameLayout
+        android:id="@+id/metainfo_overlay_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="100dp"
+        android:layout_marginEnd="100dp"
+        android:layout_marginBottom="50dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:clipToOutline="true"
+        android:elevation="4dp"
+        android:contentDescription="@string/desc_metainfo_overlay_container"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="8dp"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/meta_cover_image"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_placeholder_logo"
+                android:background="@drawable/rounded_background_coverimage"
+                android:contentDescription="@string/desc_metainfo_overlay_image"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerFamilyRounded" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:layout_marginStart="8dp">
+
+                <ViewFlipper
+                    android:id="@+id/meta_flipper"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:inAnimation="@android:anim/slide_in_left"
+                    android:outAnimation="@android:anim/slide_out_right"
+                    android:autoStart="false"
+                    android:flipInterval="10000">
+
+                    <!-- Seite 1: Titel + Artist -->
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+                        <TextView
+                            android:id="@+id/meta_overlay_Title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/primary_text_default_material_dark"
+                            android:text="@string/unknown_title"
+                            android:textSize="14sp"
+                            android:maxLines="1"
+                            android:ellipsize="end" />
+
+                        <TextView
+                            android:id="@+id/meta_overlay_Artist"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/primary_text_default_material_dark"
+                            android:text="@string/unknown_artist"
+                            android:textSize="12sp"
+                            android:maxLines="1"
+                            android:ellipsize="end" />
+                    </LinearLayout>
+
+                    <!-- Seite 2: Kombinierter Text -->
+                    <TextView
+                        android:id="@+id/meta_overlay_Album"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="marquee"
+                        android:marqueeRepeatLimit="marquee_forever"
+                        android:singleLine="true"
+                        android:scrollHorizontally="true"
+                        android:textColor="@color/primary_text_default_material_dark"
+                        android:text="@string/unknown_album"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:maxLines="1"
+                     />
+                </ViewFlipper>
+
+            </LinearLayout>
+            <ImageButton
+                android:id="@+id/button_spotify"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginEnd="5dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="0dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_button_spotify"
+                android:contentDescription="@string/desc_button_manual_log"
+                app:tint="@color/primary_dark_material_dark" />
+            <ImageButton
+                android:id="@+id/button_manual_log"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginEnd="5dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="0dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_button_manuallog"
+                android:contentDescription="@string/desc_button_manual_log"
+                app:tint="@color/primary_dark_material_dark" />
+        </LinearLayout>
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- replace generic `layout-land` files with `layout-sw360dp-land` so landscape layout only applies to S21 FE sized devices

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862c75ac9c4832fac74a608154d7f62