### PR TITLE
Add equalizer support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -39,6 +39,7 @@ import at.plankt0n.streamplay.helper.IcyStreamReader
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.SpotifyMetaReader
 import at.plankt0n.streamplay.helper.MetaLogHelper
+import at.plankt0n.streamplay.helper.EqualizerHelper
 import at.plankt0n.streamplay.data.MetaLogEntry
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.viewmodel.UITrackInfo
@@ -221,6 +222,10 @@ class StreamingService : MediaSessionService() {
 
         player.setMediaItems(mediaItems, currentIndex, 0L)
         player.prepare()
+        EqualizerHelper.init(player.audioSessionId)
+        EqualizerHelper.applyPreset(
+            PreferencesHelper.getEqualizerPreset(this)
+        )
         maybeAutoplay()
     }
 
@@ -259,6 +264,10 @@ class StreamingService : MediaSessionService() {
 
         player.setMediaItems(mediaItems, currentIndex, 0L)
         player.prepare()
+        EqualizerHelper.init(player.audioSessionId)
+        EqualizerHelper.applyPreset(
+            PreferencesHelper.getEqualizerPreset(this)
+        )
         maybeAutoplay(wasPlaying)
 
         if (wasPlaying) player.play()
@@ -308,6 +317,7 @@ class StreamingService : MediaSessionService() {
 
     override fun onDestroy() {
         ProcessLifecycleOwner.get().lifecycle.removeObserver(lifecycleObserver)
+        EqualizerHelper.release()
         mediaSession.release()
         player.release()
         super.onDestroy()

--- a/app/src/main/java/at/plankt0n/streamplay/helper/EqualizerHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/EqualizerHelper.kt
@@ -1,0 +1,39 @@
+package at.plankt0n.streamplay.helper
+
+import android.media.audiofx.Equalizer
+
+object EqualizerHelper {
+    private var equalizer: Equalizer? = null
+
+    fun init(audioSessionId: Int) {
+        release()
+        try {
+            equalizer = Equalizer(0, audioSessionId).apply {
+                enabled = true
+            }
+        } catch (_: Exception) {
+            equalizer = null
+        }
+    }
+
+    fun release() {
+        equalizer?.release()
+        equalizer = null
+    }
+
+    fun getPresets(): List<String> {
+        val eq = equalizer ?: return emptyList()
+        val list = mutableListOf<String>()
+        for (i in 0 until eq.numberOfPresets) {
+            list.add(eq.getPresetName(i.toShort()))
+        }
+        return list
+    }
+
+    fun applyPreset(index: Int) {
+        val eq = equalizer ?: return
+        if (index in 0 until eq.numberOfPresets) {
+            eq.usePreset(index.toShort())
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/helper/EqualizerHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/EqualizerHelper.kt
@@ -5,7 +5,7 @@ import android.media.audiofx.Equalizer
 object EqualizerHelper {
     private var equalizer: Equalizer? = null
 
-    fun init(audioSessionId: Int) {
+    fun init(audioSessionId: Int = 0) {
         release()
         try {
             equalizer = Equalizer(0, audioSessionId).apply {
@@ -21,8 +21,19 @@ object EqualizerHelper {
         equalizer = null
     }
 
+    private fun ensureEqualizer(): Equalizer? {
+        if (equalizer == null) {
+            try {
+                equalizer = Equalizer(0, 0).apply { enabled = true }
+            } catch (_: Exception) {
+                equalizer = null
+            }
+        }
+        return equalizer
+    }
+
     fun getPresets(): List<String> {
-        val eq = equalizer ?: return emptyList()
+        val eq = ensureEqualizer() ?: return emptyList()
         val list = mutableListOf<String>()
         for (i in 0 until eq.numberOfPresets) {
             list.add(eq.getPresetName(i.toShort()))
@@ -31,7 +42,7 @@ object EqualizerHelper {
     }
 
     fun applyPreset(index: Int) {
-        val eq = equalizer ?: return
+        val eq = ensureEqualizer() ?: return
         if (index in 0 until eq.numberOfPresets) {
             eq.usePreset(index.toShort())
         }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -12,6 +12,7 @@ object PreferencesHelper {
     private const val PREFS_NAME = "MyPrefs"
     private const val KEY_STATIONS = "stations"
     private const val PREF_LAST_PLAYED_STREAM_INDEX = "last_played_stream_index"
+    private const val PREF_EQUALIZER_PRESET = "equalizer_preset"
 
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -46,5 +47,13 @@ object PreferencesHelper {
             .edit()
             .putInt(PREF_LAST_PLAYED_STREAM_INDEX, index)
             .apply()
+    }
+
+    fun getEqualizerPreset(context: Context): Int {
+        return getPrefs(context).getInt(PREF_EQUALIZER_PRESET, 0)
+    }
+
+    fun setEqualizerPreset(context: Context, preset: Int) {
+        getPrefs(context).edit().putInt(PREF_EQUALIZER_PRESET, preset).apply()
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
@@ -1,0 +1,50 @@
+package at.plankt0n.streamplay.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.ImageButton
+import android.widget.Spinner
+import androidx.fragment.app.Fragment
+import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.helper.EqualizerHelper
+import at.plankt0n.streamplay.helper.PreferencesHelper
+
+class EqualizerFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_equalizer, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<ImageButton>(R.id.arrow_back)?.setOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+
+        val spinner = view.findViewById<Spinner>(R.id.spinnerPresets)
+        val presets = EqualizerHelper.getPresets()
+        val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, presets)
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinner.adapter = adapter
+
+        val current = PreferencesHelper.getEqualizerPreset(requireContext())
+        if (current in presets.indices) {
+            spinner.setSelection(current)
+        }
+
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                EqualizerHelper.applyPreset(position)
+                PreferencesHelper.setEqualizerPreset(requireContext(), position)
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.helper.EqualizerHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
+import android.widget.TextView
 
 class EqualizerFragment : Fragment() {
     override fun onCreateView(
@@ -28,9 +29,16 @@ class EqualizerFragment : Fragment() {
         view.findViewById<ImageButton>(R.id.arrow_back)?.setOnClickListener {
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
+        view.findViewById<TextView>(R.id.topbar_title)?.text =
+            getString(R.string.equalizer_title)
 
         val spinner = view.findViewById<Spinner>(R.id.spinnerPresets)
-        val presets = EqualizerHelper.getPresets()
+        // ensure equalizer exists so presets can be read even before playback
+        var presets = EqualizerHelper.getPresets()
+        if (presets.isEmpty()) {
+            EqualizerHelper.init(0)
+            presets = EqualizerHelper.getPresets()
+        }
         val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, presets)
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = adapter

--- a/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/EqualizerFragment.kt
@@ -8,6 +8,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.ImageButton
 import android.widget.Spinner
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.helper.EqualizerHelper
@@ -33,6 +34,12 @@ class EqualizerFragment : Fragment() {
         val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, presets)
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = adapter
+
+        if (presets.isEmpty()) {
+            spinner.isEnabled = false
+            Toast.makeText(requireContext(), R.string.equalizer_not_available, Toast.LENGTH_LONG).show()
+            return
+        }
 
         val current = PreferencesHelper.getEqualizerPreset(requireContext())
         if (current in presets.indices) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -54,6 +54,13 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_timer)
     }
 
+    val equalizerPref = Preference(context).apply {
+        key = "open_equalizer"
+        title = getString(R.string.settings_equalizer)
+        category = SettingsCategory.PLAYBACK
+        icon = context.getDrawable(R.drawable.ic_equalizer)
+    }
+
     val minimizeSwitch = SwitchPreferenceCompat(context).apply {
         key = "minimize_after_autoplay"
         title = getString(R.string.settings_minimize)
@@ -79,7 +86,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
-    val preferences = listOf(autoplaySwitch, delayPreference, minimizeSwitch, versionPref, updatePref)
+    val preferences = listOf(autoplaySwitch, delayPreference, equalizerPref, minimizeSwitch, versionPref, updatePref)
 
     SettingsCategory.values().forEach { cat ->
         val catPref = categoryMap[cat]!!

--- a/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
@@ -6,6 +6,8 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
+import at.plankt0n.streamplay.ui.EqualizerFragment
+import at.plankt0n.streamplay.ui.MediaItemOptionsBottomSheet
 import kotlinx.coroutines.launch
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -17,6 +19,16 @@ class SettingsFragment : PreferenceFragmentCompat() {
             lifecycleScope.launch {
                 GitHubUpdateChecker(requireContext()).checkForUpdate()
             }
+            true
+        }
+
+        findPreference<Preference>("open_equalizer")?.setOnPreferenceClickListener {
+            (parentFragment as? MediaItemOptionsBottomSheet)?.dismiss()
+            requireActivity().supportFragmentManager.beginTransaction()
+                .setReorderingAllowed(true)
+                .replace(R.id.fragment_container, EqualizerFragment())
+                .addToBackStack(null)
+                .commit()
             true
         }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import at.plankt0n.streamplay.Keys
+import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
 import at.plankt0n.streamplay.ui.EqualizerFragment
 import at.plankt0n.streamplay.ui.MediaItemOptionsBottomSheet

--- a/app/src/main/res/drawable/ic_equalizer.xml
+++ b/app/src/main/res/drawable/ic_equalizer.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#000000">
+    <path android:fillColor="@android:color/white" android:pathData="M6,9h2v10H6zM11,5h2v14h-2zM16,12h2v7h-2z" />
+</vector>

--- a/app/src/main/res/layout/fragment_equalizer.xml
+++ b/app/src/main/res/layout/fragment_equalizer.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/topbar" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/equalizer_select_preset"
+        android:padding="8dp" />
+
+    <Spinner
+        android:id="@+id/spinnerPresets"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <string name="settings_equalizer">Equalizer</string>
     <string name="equalizer_title">Equalizer</string>
     <string name="equalizer_select_preset">Select Preset</string>
+    <string name="equalizer_not_available">Equalizer not available</string>
     <string name="update_latest">Aktuellste Version installiert</string>
     <string name="update_checking">Checking for updates…</string>
     <string name="update_available_title">Update Available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,9 @@
     <string name="settings_category_about">About</string>
     <string name="settings_app_version">App Version</string>
     <string name="settings_check_updates">Check for Updates</string>
+    <string name="settings_equalizer">Equalizer</string>
+    <string name="equalizer_title">Equalizer</string>
+    <string name="equalizer_select_preset">Select Preset</string>
     <string name="update_latest">Aktuellste Version installiert</string>
     <string name="update_checking">Checking for updates…</string>
     <string name="update_available_title">Update Available</string>


### PR DESCRIPTION
## Summary
- manage audio presets with `EqualizerHelper`
- provide `EqualizerFragment` for users to select presets
- open the equalizer screen from settings
- persist and apply selected presets
- new resources and icons

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e6e4bcc0832f9ab46993e57b2023