### PR TITLE
Update metadata refresh to update UI track info

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -517,6 +517,14 @@ val artist = refreshMetaData?.artist?.toString().orEmpty()
 val title = refreshMetaData?.title?.toString().orEmpty()
         val artworkUri = refreshMetaData?.artworkUri?.toString().orEmpty()
 
+        UITrackViewModel.updateTrackInfo(
+            UITrackInfo(
+                trackName = title,
+                artistName = artist,
+                bestCoverUrl = artworkUri.takeIf { it.isNotBlank() }
+            )
+        )
+
         if (isInForeground) {
             updateartist = artist
             updatetitle = title


### PR DESCRIPTION
## Summary
- push refreshed metadata back to the UI inside `refreshMediaItemMetadata`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cd3ca230832fa213fb0c780f0a3d