### PR TITLE
Fix build errors and cleanup project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# StreamPlay
+
+An Android streaming audio application.
+
+## Build Requirements
+
+- Android Studio Giraffe or later
+- Android SDK with API 35
+- Gradle 8+
+
+## Building
+
+Run `./gradlew assembleDebug` to build the debug APK. The project uses
+`spotifyClientId` and `spotifyClientSecret` Gradle properties for optional
+Spotify metadata features. Create a `local.properties` file in the project root
+and add:
+
+```
+spotifyClientId=YOUR_CLIENT_ID
+spotifyClientSecret=YOUR_CLIENT_SECRET
+```
+
+If these values are omitted, Spotify lookups will be disabled.
+
+## Usage
+
+Install the APK on your device and launch *StreamPlay*. Configure stations in the
+app and start streaming your favourite content.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,10 @@ android {
     namespace = "at.plankt0n.streamplay"
     compileSdk = 35
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId = "at.plankt0n.streamplay"
         minSdk = 29
@@ -16,6 +20,17 @@ android {
         versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField(
+            "String",
+            "SPOTIFY_CLIENT_ID",
+            "\"${project.findProperty("spotifyClientId") ?: ""}\""
+        )
+        buildConfigField(
+            "String",
+            "SPOTIFY_CLIENT_SECRET",
+            "\"${project.findProperty("spotifyClientSecret") ?: ""}\""
+        )
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="at.plankt0n.streamplay">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -1,5 +1,6 @@
 package at.plankt0n.streamplay
 
+import at.plankt0n.streamplay.BuildConfig
 import java.util.Date
 
 object Keys {
@@ -13,9 +14,9 @@ object Keys {
 
 
 
-    //Spotify
-    const val KEY_SPOTIFY_CLIENT_ID = "cc55a94b922c496a84c4a725242a313b"
-    const val KEY_SPOTIFY_CLIENT_SECRET = "1893b26ecec74a4984152f0d86200b63"
+    //Spotify credentials are provided via BuildConfig
+    const val KEY_SPOTIFY_CLIENT_ID = BuildConfig.SPOTIFY_CLIENT_ID
+    const val KEY_SPOTIFY_CLIENT_SECRET = BuildConfig.SPOTIFY_CLIENT_SECRET
 
     const val KEY_META_LOGS_PREFS = "meta_log_prefs"
     const val KEY_META_LOGS = "metadata_logs"

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -42,8 +42,10 @@ import at.plankt0n.streamplay.helper.MetaLogHelper
 import at.plankt0n.streamplay.data.MetaLogEntry
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.viewmodel.UITrackInfo
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
@@ -68,6 +70,8 @@ class StreamingService : MediaSessionService() {
     companion object {
         const val CHANNEL_ID = "stream_service_channel"
     }
+
+    private val serviceScope = MainScope()
 
     private var hasSeenForeground = false
     private val lifecycleObserver = object : DefaultLifecycleObserver {
@@ -308,6 +312,7 @@ class StreamingService : MediaSessionService() {
 
     override fun onDestroy() {
         ProcessLifecycleOwner.get().lifecycle.removeObserver(lifecycleObserver)
+        serviceScope.cancel()
         mediaSession.release()
         player.release()
         super.onDestroy()
@@ -366,7 +371,7 @@ class StreamingService : MediaSessionService() {
         }
 
         if (artist.isNotEmpty() && title.isNotEmpty()) {
-            GlobalScope.launch(Dispatchers.IO) {
+            serviceScope.launch(Dispatchers.IO) {
                 val extendedInfo =
                     SpotifyMetaReader.getExtendedMetaInfo(this@StreamingService, artist, title)
                 withContext(Dispatchers.Main) {
@@ -439,7 +444,7 @@ class StreamingService : MediaSessionService() {
                 "⚠️ Artist oder Title fehlen – kein Spotify-Request. Fallback auf alte meta"
             )
             // Sicherstellen, dass auch dieser Aufruf im Main-Thread läuft!
-            GlobalScope.launch(Dispatchers.Main) {
+            serviceScope.launch(Dispatchers.Main) {
                 updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
             }
             UITrackViewModel.updateTrackInfo(

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -4,14 +4,15 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.data.StationItem
+import at.plankt0n.streamplay.Keys
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 object PreferencesHelper {
 
-    private const val PREFS_NAME = "MyPrefs"
-    private const val KEY_STATIONS = "stations"
-    private const val PREF_LAST_PLAYED_STREAM_INDEX = "last_played_stream_index"
+    private const val PREFS_NAME = Keys.PREFS_NAME
+    private const val KEY_STATIONS = Keys.KEY_STATIONS
+    private const val PREF_LAST_PLAYED_STREAM_INDEX = Keys.PREF_LAST_PLAYED_STREAM_INDEX
 
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -2,6 +2,7 @@ package at.plankt0n.streamplay.ui
 
 import androidx.preference.*
 import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.Keys
 
 /** Possible categories a preference can belong to. */
 enum class SettingsCategory { PLAYBACK, UI, METAINFO, ABOUT }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
 
 
     <!-- Sheet Menu -->
-    !-- Bottom Sheet -->
+    <!-- Bottom Sheet -->
     <string name="bottom_sheet_title">Aktionen</string>
     <!-- Option 1: Station Setup -->
     <string name="bottom_sheet_station_text">Stations öffnen</string>


### PR DESCRIPTION
## Summary
- fix missing import in `Settings.kt`
- correct malformed XML comment
- remove deprecated package attribute from manifest
- replace `GlobalScope` usage with service-scoped coroutines
- read Spotify credentials from BuildConfig
- centralize preference keys
- enable BuildConfig generation and expose Spotify fields
- add basic README

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a52960838832fa11cdb6ae5725299