### PR TITLE
Display connecting banner

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -11,6 +11,8 @@ object Keys {
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
 
+    const val PREF_SHOW_EXOPLAYER_INFO = "show_exoplayer_info"
+
 
 
     //Spotify

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.PlaybackException
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
@@ -26,6 +27,8 @@ class MediaServiceController(private val context: Context) {
     fun initializeAndConnect(
         onConnected: (MediaController) -> Unit,
         onPlaybackChanged: (Boolean) -> Unit,
+        onPlaybackStateChanged: (Int) -> Unit,
+        onPlaybackError: (PlaybackException) -> Unit,
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
         onTimelineChanged: (Int) -> Unit
@@ -48,6 +51,14 @@ class MediaServiceController(private val context: Context) {
                 listener = object : Player.Listener {
                     override fun onIsPlayingChanged(isPlaying: Boolean) {
                         onPlaybackChanged(isPlaying)
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        onPlaybackStateChanged(playbackState)
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        onPlaybackError(error)
                     }
 
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -38,6 +38,7 @@ import at.plankt0n.streamplay.Keys
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
+import androidx.media3.common.Player
 
 class PlayerFragment : Fragment() {
 
@@ -62,6 +63,13 @@ class PlayerFragment : Fragment() {
     private lateinit var countdownTextView: TextView
     private val countdownHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
+    private lateinit var sharedPreferences: android.content.SharedPreferences
+    private val prefListener =
+        android.content.SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+            if (key == Keys.PREF_SHOW_EXOPLAYER_INFO && !prefs.getBoolean(Keys.PREF_SHOW_EXOPLAYER_INFO, true)) {
+                connectionStatusBanner.visibility = View.GONE
+            }
+        }
 
     private val autoplayReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -76,6 +84,8 @@ class PlayerFragment : Fragment() {
     }
 
     var isMuted = false
+    private lateinit var connectionStatusBanner: TextView
+    private var baseStationName: String = ""
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -116,6 +126,10 @@ class PlayerFragment : Fragment() {
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
+        connectionStatusBanner = view.findViewById(R.id.connection_status_banner)
+
+        sharedPreferences = requireContext().getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        sharedPreferences.registerOnSharedPreferenceChangeListener(prefListener)
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -188,6 +202,42 @@ class PlayerFragment : Fragment() {
 
             },
             onPlaybackChanged = { updatePlayPauseIcon(it) },
+            onPlaybackStateChanged = { state ->
+                val showBanner = sharedPreferences.getBoolean(Keys.PREF_SHOW_EXOPLAYER_INFO, true)
+                if (!showBanner) {
+                    connectionStatusBanner.visibility = View.GONE
+                }
+
+                if (state == Player.STATE_BUFFERING) {
+                    if (showBanner) {
+                        connectionStatusBanner.text = getString(R.string.connecting)
+                        connectionStatusBanner.setBackgroundColor(
+                            requireContext().getColor(R.color.banner_connecting)
+                        )
+                        connectionStatusBanner.visibility = View.VISIBLE
+                    }
+                    updateStationName(true)
+                } else if (state == Player.STATE_READY) {
+                    if (showBanner) {
+                        connectionStatusBanner.visibility = View.GONE
+                    }
+                    updateStationName(false)
+                }
+            },
+            onPlaybackError = { error ->
+                val showBanner = sharedPreferences.getBoolean(Keys.PREF_SHOW_EXOPLAYER_INFO, true)
+                if (!showBanner) return@initializeAndConnect
+
+                val msg = error.message ?: error.errorCodeName
+                connectionStatusBanner.text = getString(
+                    R.string.connection_error,
+                    msg
+                )
+                connectionStatusBanner.setBackgroundColor(
+                    requireContext().getColor(R.color.banner_error)
+                )
+                connectionStatusBanner.visibility = View.VISIBLE
+            },
             onStreamIndexChanged = { index ->
                 viewPager.setCurrentItem(index, true)
                 updateOverlayUI(index)
@@ -354,7 +404,7 @@ class PlayerFragment : Fragment() {
 
         val stationName = extras.getString("EXTRA_STATION_NAME") ?: ""
         val iconUrl = extras.getString("EXTRA_ICON_URL") ?: ""
-
+        baseStationName = stationName
         stationNameTextView.text = stationName
         Glide.with(stationIconImageView)
             .load(iconUrl)
@@ -367,6 +417,17 @@ class PlayerFragment : Fragment() {
         val iconRes = if (isPlaying) R.drawable.ic_button_pause else R.drawable.ic_button_play
         playPauseButton.setImageResource(iconRes)
     }
+
+    private fun updateStationName(isBuffering: Boolean) {
+        val text = if (isBuffering) {
+            baseStationName + " - " + getString(R.string.connecting)
+        } else {
+            baseStationName
+        }
+        stationNameTextView.text = text
+    }
+
+
 
     private fun reloadPlaylist() {
         val controller = mediaServiceController.mediaController ?: return
@@ -404,6 +465,7 @@ class PlayerFragment : Fragment() {
         if (initialized) {
             requireContext().unregisterReceiver(autoplayReceiver)
             countdownHandler.removeCallbacksAndMessages(null)
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(prefListener)
             mediaServiceController.disconnect()
         }
         super.onDestroyView()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -62,6 +62,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_pip)
     }
 
+    val exoplayerInfoSwitch = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_SHOW_EXOPLAYER_INFO
+        title = getString(R.string.settings_show_exoplayer_info)
+        setDefaultValue(true)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_radio)
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -79,7 +87,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
-    val preferences = listOf(autoplaySwitch, delayPreference, minimizeSwitch, versionPref, updatePref)
+    val preferences = listOf(
+        autoplaySwitch,
+        delayPreference,
+        minimizeSwitch,
+        exoplayerInfoSwitch,
+        versionPref,
+        updatePref
+    )
 
     SettingsCategory.values().forEach { cat ->
         val catPref = categoryMap[cat]!!

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -158,6 +158,8 @@ class StationsFragment : Fragment() {
                 adapter.setCurrentPlayingIndex(controller.currentMediaItemIndex)
             },
             onPlaybackChanged = {},
+            onPlaybackStateChanged = {},
+            onPlaybackError = {},
             onStreamIndexChanged = { idx -> adapter.setCurrentPlayingIndex(idx) },
             onMetadataChanged = {},
             onTimelineChanged = {}

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -38,6 +38,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/connection_status_banner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@color/banner_connecting"
+        android:padding="8dp"
+        android:text="@string/connecting"
+        android:textColor="@android:color/white"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/autoplay_countdown"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Player Buttons -->
     <LinearLayout
         android:id="@+id/player_buttons_group"

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -38,6 +38,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/connection_status_banner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@color/banner_connecting"
+        android:padding="8dp"
+        android:text="@string/connecting"
+        android:textColor="@android:color/white"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/autoplay_countdown"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Cover Image -->
 
     <!-- Player Buttons -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -109,4 +109,8 @@
     <color name="default_background">#CCCCCC</color> <!-- Hellgrau -->
     <color name="default_transparent">#00ffffff</color>
 
+    <!-- lighter and semi-transparent banner colors -->
+    <color name="banner_connecting">#80BBDEFB</color>
+    <color name="banner_error">#80FFCDD2</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="settings_category_ui">UI Settings</string>
     <string name="settings_category_metainfo">Metainfo Settings</string>
     <string name="settings_category_about">About</string>
+    <string name="settings_show_exoplayer_info">Zeige Exoplayer Information</string>
     <string name="settings_app_version">App Version</string>
     <string name="settings_check_updates">Check for Updates</string>
     <string name="update_latest">Aktuellste Version installiert</string>
@@ -122,5 +123,7 @@
     <string name="update_download_fail">Download fehlgeschlagen</string>
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
+    <string name="connecting">Connecting…</string>
+    <string name="connection_error">Error: %1$s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
 </resources>


### PR DESCRIPTION
## Summary
- show full-width connection status banner at the top of player overlay
- color banner blue when buffering and red when errors occur
- surface playback errors from ExoPlayer through MediaServiceController
- lighten banner colors for a translucent look
- add a toggle in UI settings to hide or show the connection banner
- hide the banner immediately if the preference is turned off
- append "- Connecting…" to the station name while buffering

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1a2d63b8832f85b11808dbe3b546