### PR TITLE
Add ExoPlayer status banner

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -11,6 +11,9 @@ object Keys {
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
 
+    /** How long the "Connected!" banner stays visible (ms) */
+    const val CONNECTED_STATUS_DURATION_MS = 1000L
+
 
 
     //Spotify

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.PlaybackException
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
@@ -28,7 +29,9 @@ class MediaServiceController(private val context: Context) {
         onPlaybackChanged: (Boolean) -> Unit,
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
-        onTimelineChanged: (Int) -> Unit
+        onTimelineChanged: (Int) -> Unit,
+        onPlayerStateChanged: (Int) -> Unit = {},
+        onPlayerError: (PlaybackException) -> Unit = {}
     ) {
         // Service als Foreground starten
         val serviceIntent = Intent(context, StreamingService::class.java)
@@ -50,6 +53,10 @@ class MediaServiceController(private val context: Context) {
                         onPlaybackChanged(isPlaying)
                     }
 
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        onPlayerStateChanged(playbackState)
+                    }
+
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                         handler.postDelayed({
                             val index = controller.currentMediaItemIndex
@@ -68,6 +75,10 @@ class MediaServiceController(private val context: Context) {
                             Log.d("MediaServiceController", "ℹ️ Timeline-Änderung ignoriert (Grund: $reason)")
                         }
 
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        onPlayerError(error)
                     }
 
                     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -77,8 +77,10 @@ class PlayerFragment : Fragment() {
         }
     }
 
-    var isMuted = false
-    private var showStatusEnabled = true
+var isMuted = false
+private var showStatusEnabled = true
+private var lastPlayerState: Int = Player.STATE_IDLE
+private var hideStatusRunnable: Runnable? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -207,12 +209,21 @@ class PlayerFragment : Fragment() {
             },
             onPlayerStateChanged = { state ->
                 when (state) {
-                    Player.STATE_BUFFERING -> showStatus(getString(R.string.exo_status_connecting), false)
-                    Player.STATE_READY -> hideStatus()
+                    Player.STATE_BUFFERING -> {
+                        showStatus(getString(R.string.exo_status_connecting), StatusType.CONNECTING)
+                    }
+                    Player.STATE_READY -> {
+                        if (lastPlayerState == Player.STATE_BUFFERING || lastPlayerState == Player.STATE_IDLE) {
+                            showStatus(getString(R.string.exo_status_connected), StatusType.SUCCESS)
+                        } else {
+                            hideStatus()
+                        }
+                    }
                 }
+                lastPlayerState = state
             },
             onPlayerError = { error ->
-                showStatus(error.message ?: "Unknown error", true)
+                showStatus(error.message ?: "Unknown error", StatusType.ERROR)
             }
         )
 
@@ -460,16 +471,32 @@ class PlayerFragment : Fragment() {
         countdownTextView.visibility = View.GONE
     }
 
-    private fun showStatus(text: String, isError: Boolean) {
+    private enum class StatusType { CONNECTING, ERROR, SUCCESS }
+
+    private fun showStatus(text: String, type: StatusType) {
         if (!showStatusEnabled) return
+        hideStatusRunnable?.let { countdownHandler.removeCallbacks(it) }
+
         exoStatusBanner.text = text
-        exoStatusBanner.setBackgroundResource(
-            if (isError) R.drawable.banner_error_bg else R.drawable.banner_connecting_bg
-        )
+        val bg = when (type) {
+            StatusType.CONNECTING -> R.drawable.banner_connecting_bg
+            StatusType.ERROR -> R.drawable.banner_error_bg
+            StatusType.SUCCESS -> R.drawable.banner_connected_bg
+        }
+        exoStatusBanner.setBackgroundResource(bg)
         exoStatusBanner.visibility = View.VISIBLE
+
+        if (type == StatusType.SUCCESS) {
+            hideStatusRunnable = Runnable { hideStatus() }
+            countdownHandler.postDelayed(hideStatusRunnable!!, 2000)
+        } else {
+            hideStatusRunnable = null
+        }
     }
 
     private fun hideStatus() {
+        hideStatusRunnable?.let { countdownHandler.removeCallbacks(it) }
+        hideStatusRunnable = null
         exoStatusBanner.visibility = View.GONE
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -488,7 +488,10 @@ private var hideStatusRunnable: Runnable? = null
 
         if (type == StatusType.SUCCESS) {
             hideStatusRunnable = Runnable { hideStatus() }
-            countdownHandler.postDelayed(hideStatusRunnable!!, 1000)
+            countdownHandler.postDelayed(
+                hideStatusRunnable!!,
+                Keys.CONNECTED_STATUS_DURATION_MS
+            )
         } else {
             hideStatusRunnable = null
         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -488,7 +488,7 @@ private var hideStatusRunnable: Runnable? = null
 
         if (type == StatusType.SUCCESS) {
             hideStatusRunnable = Runnable { hideStatus() }
-            countdownHandler.postDelayed(hideStatusRunnable!!, 2000)
+            countdownHandler.postDelayed(hideStatusRunnable!!, 1000)
         } else {
             hideStatusRunnable = null
         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -35,6 +35,7 @@ import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
+import androidx.media3.common.Player
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
@@ -60,6 +61,7 @@ class PlayerFragment : Fragment() {
     private lateinit var shortcutRecyclerView: RecyclerView
     private lateinit var shortcutAdapter: ShortcutAdapter
     private lateinit var countdownTextView: TextView
+    private lateinit var exoStatusBanner: TextView
     private val countdownHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
 
@@ -76,6 +78,7 @@ class PlayerFragment : Fragment() {
     }
 
     var isMuted = false
+    private var showStatusEnabled = true
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -116,6 +119,11 @@ class PlayerFragment : Fragment() {
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
+        exoStatusBanner = view.findViewById(R.id.exoplayer_status_banner)
+
+        val prefs = requireContext().getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        showStatusEnabled = prefs.getBoolean("show_exoplayer_status", true)
+        if (!showStatusEnabled) exoStatusBanner.visibility = View.GONE
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -194,8 +202,17 @@ class PlayerFragment : Fragment() {
             },
             onMetadataChanged = {},
             onTimelineChanged = {
-                Log.d("PlayerFragment", "\ud83d\udd01 Timeline ge\u00e4ndert! Grund: $it")
+                Log.d("PlayerFragment", "\uD83D\uDD01 Timeline ge\u00e4ndert! Grund: $it")
                 reloadPlaylist()
+            },
+            onPlayerStateChanged = { state ->
+                when (state) {
+                    Player.STATE_BUFFERING -> showStatus(getString(R.string.exo_status_connecting), false)
+                    Player.STATE_READY -> hideStatus()
+                }
+            },
+            onPlayerError = { error ->
+                showStatus(error.message ?: "Unknown error", true)
             }
         )
 
@@ -441,5 +458,18 @@ class PlayerFragment : Fragment() {
     private fun hideCountdown() {
         countdownRunnable?.let { countdownHandler.removeCallbacks(it) }
         countdownTextView.visibility = View.GONE
+    }
+
+    private fun showStatus(text: String, isError: Boolean) {
+        if (!showStatusEnabled) return
+        exoStatusBanner.text = text
+        exoStatusBanner.setBackgroundResource(
+            if (isError) R.drawable.banner_error_bg else R.drawable.banner_connecting_bg
+        )
+        exoStatusBanner.visibility = View.VISIBLE
+    }
+
+    private fun hideStatus() {
+        exoStatusBanner.visibility = View.GONE
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -62,6 +62,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_pip)
     }
 
+    val showStatusSwitch = SwitchPreferenceCompat(context).apply {
+        key = "show_exoplayer_status"
+        title = getString(R.string.settings_show_exoplayer_status)
+        setDefaultValue(true)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_radio)
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -79,7 +87,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
-    val preferences = listOf(autoplaySwitch, delayPreference, minimizeSwitch, versionPref, updatePref)
+    val preferences = listOf(
+        autoplaySwitch,
+        delayPreference,
+        minimizeSwitch,
+        showStatusSwitch,
+        versionPref,
+        updatePref
+    )
 
     SettingsCategory.values().forEach { cat ->
         val catPref = categoryMap[cat]!!

--- a/app/src/main/res/drawable/banner_connected_bg.xml
+++ b/app/src/main/res/drawable/banner_connected_bg.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#804CAF50" />
+</shape>

--- a/app/src/main/res/drawable/banner_connecting_bg.xml
+++ b/app/src/main/res/drawable/banner_connecting_bg.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#802196F3" />
+</shape>

--- a/app/src/main/res/drawable/banner_error_bg.xml
+++ b/app/src/main/res/drawable/banner_error_bg.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#80F44336" />
+</shape>

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -35,6 +35,7 @@
         android:textColor="@android:color/white"
         android:gravity="center"
         android:visibility="gone"
+        android:contentDescription="@string/desc_exoplayer_status_banner"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -26,6 +26,20 @@
         app:layout_constraintGuide_percent="0.65" />
 
     <TextView
+        android:id="@+id/exoplayer_status_banner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/banner_connecting_bg"
+        android:padding="8dp"
+        android:text="@string/exo_status_connecting"
+        android:textColor="@android:color/white"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
         android:id="@+id/autoplay_countdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -34,7 +48,7 @@
         android:padding="8dp"
         android:textColor="@android:color/black"
         android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/exoplayer_status_banner"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -35,6 +35,7 @@
         android:textColor="@android:color/white"
         android:gravity="center"
         android:visibility="gone"
+        android:contentDescription="@string/desc_exoplayer_status_banner"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -26,6 +26,20 @@
         app:layout_constraintGuide_percent="0.65" />
 
     <TextView
+        android:id="@+id/exoplayer_status_banner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/banner_connecting_bg"
+        android:padding="8dp"
+        android:text="@string/exo_status_connecting"
+        android:textColor="@android:color/white"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
         android:id="@+id/autoplay_countdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -34,7 +48,7 @@
         android:padding="8dp"
         android:textColor="@android:color/black"
         android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/exoplayer_status_banner"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,5 +125,6 @@
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
     <string name="settings_show_exoplayer_status">Show ExoPlayer Status</string>
     <string name="exo_status_connecting">Connecting…</string>
+    <string name="exo_status_connected">Connected!</string>
     <string name="desc_exoplayer_status_banner">Status of ExoPlayer</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,7 @@
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
+    <string name="settings_show_exoplayer_status">Show ExoPlayer Status</string>
+    <string name="exo_status_connecting">Connecting…</string>
+    <string name="desc_exoplayer_status_banner">Status of ExoPlayer</string>
 </resources>


### PR DESCRIPTION
## Summary
- display ExoPlayer connection status at top of player
- allow toggling banner in UI settings
- report player errors in red banner
- add resources for banner backgrounds

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a63cda02c832f8f504ca0636f79c1