### PR TITLE
Add ExoPlayer status banner

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -10,6 +10,7 @@ object Keys {
     const val ACTION_SHOW_COUNTDOWN = "at.plankt0n.streamplay.SHOW_COUNTDOWN"
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
+    const val EXO_CONNECTED_DISPLAY_MS = 2000
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.PlaybackException
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
@@ -28,7 +29,8 @@ class MediaServiceController(private val context: Context) {
         onPlaybackChanged: (Boolean) -> Unit,
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
-        onTimelineChanged: (Int) -> Unit
+        onTimelineChanged: (Int) -> Unit,
+        onPlayerError: (String) -> Unit
     ) {
         // Service als Foreground starten
         val serviceIntent = Intent(context, StreamingService::class.java)
@@ -48,6 +50,10 @@ class MediaServiceController(private val context: Context) {
                 listener = object : Player.Listener {
                     override fun onIsPlayingChanged(isPlaying: Boolean) {
                         onPlaybackChanged(isPlaying)
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        onPlayerError(error.cause?.message ?: error.message ?: "Unknown error")
                     }
 
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -19,6 +19,7 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.ViewFlipper
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -60,6 +61,10 @@ class PlayerFragment : Fragment() {
     private lateinit var shortcutRecyclerView: RecyclerView
     private lateinit var shortcutAdapter: ShortcutAdapter
     private lateinit var countdownTextView: TextView
+    private lateinit var statusBanner: TextView
+    private val statusHandler = Handler(Looper.getMainLooper())
+    private var statusRunnable: Runnable? = null
+    private var showStatusBannerPref = true
     private val countdownHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
 
@@ -117,6 +122,9 @@ class PlayerFragment : Fragment() {
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
+        statusBanner = view.findViewById(R.id.exoplayer_status_banner)
+        val prefs = requireContext().getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        showStatusBannerPref = prefs.getBoolean("show_exoplayer_status", true)
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -134,8 +142,14 @@ class PlayerFragment : Fragment() {
         requireContext().registerReceiver(autoplayReceiver, filter, flags)
 
         mediaServiceController = MediaServiceController(requireContext())
+        if (showStatusBannerPref) {
+            showStatus(getString(R.string.exoplayer_status_connecting), R.drawable.rounded_blue_transparent_bg)
+        }
         mediaServiceController.initializeAndConnect(
             onConnected = { controller ->
+                if (showStatusBannerPref) {
+                    showStatus(getString(R.string.exoplayer_status_connected), R.drawable.rounded_green_transparent_bg, true)
+                }
                 val shortcuts = (0 until controller.mediaItemCount).mapNotNull { i ->
                     val mediaItem = controller.getMediaItemAt(i)
                     val extras = mediaItem.mediaMetadata.extras ?: return@mapNotNull null
@@ -188,7 +202,10 @@ class PlayerFragment : Fragment() {
                 })
 
             },
-            onPlaybackChanged = { updatePlayPauseIcon(it) },
+            onPlaybackChanged = { playing ->
+                updatePlayPauseIcon(playing)
+                if (playing && showStatusBannerPref) hideStatus()
+            },
             onStreamIndexChanged = { index ->
                 viewPager.setCurrentItem(index, true)
                 updateOverlayUI(index)
@@ -197,6 +214,12 @@ class PlayerFragment : Fragment() {
             onTimelineChanged = {
                 Log.d("PlayerFragment", "\ud83d\udd01 Timeline ge\u00e4ndert! Grund: $it")
                 reloadPlaylist()
+            }
+            ,
+            onPlayerError = { error ->
+                if (showStatusBannerPref) {
+                    showStatus(error, R.drawable.rounded_red_transparent_bg)
+                }
             }
         )
 
@@ -429,6 +452,7 @@ class PlayerFragment : Fragment() {
         if (initialized) {
             requireContext().unregisterReceiver(autoplayReceiver)
             countdownHandler.removeCallbacksAndMessages(null)
+            statusHandler.removeCallbacksAndMessages(null)
             mediaServiceController.disconnect()
         }
         super.onDestroyView()
@@ -466,5 +490,21 @@ class PlayerFragment : Fragment() {
     private fun hideCountdown() {
         countdownRunnable?.let { countdownHandler.removeCallbacks(it) }
         countdownTextView.visibility = View.GONE
+    }
+
+    private fun showStatus(text: String, backgroundRes: Int, autoHide: Boolean = false) {
+        statusRunnable?.let { statusHandler.removeCallbacks(it) }
+        statusBanner.text = text
+        statusBanner.background = ContextCompat.getDrawable(requireContext(), backgroundRes)
+        statusBanner.visibility = View.VISIBLE
+        if (autoHide) {
+            statusRunnable = Runnable { statusBanner.visibility = View.GONE }
+            statusHandler.postDelayed(statusRunnable!!, Keys.EXO_CONNECTED_DISPLAY_MS.toLong())
+        }
+    }
+
+    private fun hideStatus() {
+        statusRunnable?.let { statusHandler.removeCallbacks(it) }
+        statusBanner.visibility = View.GONE
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -62,6 +62,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_pip)
     }
 
+    val showStatusSwitch = SwitchPreferenceCompat(context).apply {
+        key = "show_exoplayer_status"
+        title = getString(R.string.settings_show_exoplayer_status)
+        setDefaultValue(true)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_radio)
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -79,7 +87,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
-    val preferences = listOf(autoplaySwitch, delayPreference, minimizeSwitch, versionPref, updatePref)
+    val preferences = listOf(
+        autoplaySwitch,
+        delayPreference,
+        minimizeSwitch,
+        showStatusSwitch,
+        versionPref,
+        updatePref
+    )
 
     SettingsCategory.values().forEach { cat ->
         val catPref = categoryMap[cat]!!

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -160,7 +160,8 @@ class StationsFragment : Fragment() {
             onPlaybackChanged = {},
             onStreamIndexChanged = { idx -> adapter.setCurrentPlayingIndex(idx) },
             onMetadataChanged = {},
-            onTimelineChanged = {}
+            onTimelineChanged = {},
+            onPlayerError = {}
         )
 
         view.findViewById<View>(R.id.buttonAddStation).setOnClickListener {

--- a/app/src/main/res/drawable/rounded_blue_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_blue_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#80007bff" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_green_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_green_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#8000ff00" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_red_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_red_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#80ff0000" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -26,6 +26,20 @@
         app:layout_constraintGuide_percent="0.65" />
 
     <TextView
+        android:id="@+id/exoplayer_status_banner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rounded_blue_transparent_bg"
+        android:padding="8dp"
+        android:textColor="@android:color/white"
+        android:text="@string/exoplayer_status_connecting"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
         android:id="@+id/autoplay_countdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -34,7 +48,7 @@
         android:padding="8dp"
         android:textColor="@android:color/black"
         android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/exoplayer_status_banner"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="settings_category_about">About</string>
     <string name="settings_app_version">App Version</string>
     <string name="settings_check_updates">Check for Updates</string>
+    <string name="settings_show_exoplayer_status">Show Exoplayer Status</string>
     <string name="update_latest">Aktuellste Version installiert</string>
     <string name="update_checking">Checking for updates…</string>
     <string name="update_available_title">Update Available</string>
@@ -121,6 +122,8 @@
     <string name="update_downloading">Downloading update…</string>
     <string name="update_download_fail">Download fehlgeschlagen</string>
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
+    <string name="exoplayer_status_connecting">Connecting…</string>
+    <string name="exoplayer_status_connected">Connected</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
 </resources>


### PR DESCRIPTION
## Summary
- show ExoPlayer connection state as banner below the status bar
- allow disabling the banner in the settings
- keep "Connected" banner visible for a short time via constant
- display errors from ExoPlayer in red

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6e38851c832f875c2854b457f0f2