### PR TITLE
Add connection banner for ExoPlayer status

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -10,6 +10,7 @@ object Keys {
     const val ACTION_SHOW_COUNTDOWN = "at.plankt0n.streamplay.SHOW_COUNTDOWN"
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
+    const val BANNER_HIDE_DELAY_MS = 1000L
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.PlaybackException
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
@@ -28,7 +29,9 @@ class MediaServiceController(private val context: Context) {
         onPlaybackChanged: (Boolean) -> Unit,
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
-        onTimelineChanged: (Int) -> Unit
+        onTimelineChanged: (Int) -> Unit,
+        onPlaybackStateChanged: (Int) -> Unit,
+        onPlayerError: (PlaybackException) -> Unit
     ) {
         // Service als Foreground starten
         val serviceIntent = Intent(context, StreamingService::class.java)
@@ -68,6 +71,14 @@ class MediaServiceController(private val context: Context) {
                             Log.d("MediaServiceController", "ℹ️ Timeline-Änderung ignoriert (Grund: $reason)")
                         }
 
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        onPlaybackStateChanged(playbackState)
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        onPlayerError(error)
                     }
 
                     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -35,6 +35,7 @@ import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
+import androidx.media3.common.Player
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
@@ -60,8 +61,11 @@ class PlayerFragment : Fragment() {
     private lateinit var shortcutRecyclerView: RecyclerView
     private lateinit var shortcutAdapter: ShortcutAdapter
     private lateinit var countdownTextView: TextView
+    private lateinit var connectionBanner: TextView
     private val countdownHandler = Handler(Looper.getMainLooper())
+    private val bannerHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
+    private var bannerRunnable: Runnable? = null
 
     private val autoplayReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -117,6 +121,7 @@ class PlayerFragment : Fragment() {
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
+        connectionBanner = view.findViewById(R.id.connection_banner)
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -190,13 +195,37 @@ class PlayerFragment : Fragment() {
             },
             onPlaybackChanged = { updatePlayPauseIcon(it) },
             onStreamIndexChanged = { index ->
+            onStreamIndexChanged = { index ->
                 viewPager.setCurrentItem(index, true)
                 updateOverlayUI(index)
             },
             onMetadataChanged = {},
             onTimelineChanged = {
-                Log.d("PlayerFragment", "\ud83d\udd01 Timeline ge\u00e4ndert! Grund: $it")
+                Log.d("PlayerFragment", "\uD83D\uDD01 Timeline ge\u00e4ndert! Grund: $it")
                 reloadPlaylist()
+            },
+            onPlaybackStateChanged = { state ->
+                when (state) {
+                    Player.STATE_BUFFERING -> showBanner(
+                        getString(R.string.banner_connecting),
+                        R.drawable.banner_bg_blue,
+                        false
+                    )
+                    Player.STATE_READY -> if (mediaServiceController.isPlaying()) {
+                        showBanner(
+                            getString(R.string.banner_connected),
+                            R.drawable.banner_bg_green,
+                            true
+                        )
+                    }
+                }
+            },
+            onPlayerError = { error ->
+                showBanner(
+                    getString(R.string.banner_error, error.errorCodeName),
+                    R.drawable.banner_bg_red,
+                    false
+                )
             }
         )
 
@@ -466,5 +495,16 @@ class PlayerFragment : Fragment() {
     private fun hideCountdown() {
         countdownRunnable?.let { countdownHandler.removeCallbacks(it) }
         countdownTextView.visibility = View.GONE
+    }
+
+    private fun showBanner(text: String, backgroundRes: Int, hide: Boolean) {
+        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
+        connectionBanner.setBackgroundResource(backgroundRes)
+        connectionBanner.text = text
+        connectionBanner.visibility = View.VISIBLE
+        if (hide) {
+            bannerRunnable = Runnable { connectionBanner.visibility = View.GONE }
+            bannerHandler.postDelayed(bannerRunnable!!, Keys.BANNER_HIDE_DELAY_MS)
+        }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -160,7 +160,9 @@ class StationsFragment : Fragment() {
             onPlaybackChanged = {},
             onStreamIndexChanged = { idx -> adapter.setCurrentPlayingIndex(idx) },
             onMetadataChanged = {},
-            onTimelineChanged = {}
+            onTimelineChanged = {},
+            onPlaybackStateChanged = {},
+            onPlayerError = {}
         )
 
         view.findViewById<View>(R.id.buttonAddStation).setOnClickListener {

--- a/app/src/main/res/drawable/banner_bg_blue.xml
+++ b/app/src/main/res/drawable/banner_bg_blue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/banner_blue" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/banner_bg_green.xml
+++ b/app/src/main/res/drawable/banner_bg_green.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/banner_green" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/banner_bg_red.xml
+++ b/app/src/main/res/drawable/banner_bg_red.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/banner_red" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -26,6 +26,18 @@
         app:layout_constraintGuide_percent="0.65" />
 
     <TextView
+        android:id="@+id/connection_banner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/banner_bg_blue"
+        android:padding="8dp"
+        android:textColor="@android:color/white"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
         android:id="@+id/autoplay_countdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -26,6 +26,18 @@
         app:layout_constraintGuide_percent="0.65" />
 
     <TextView
+        android:id="@+id/connection_banner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/banner_bg_blue"
+        android:padding="8dp"
+        android:textColor="@android:color/white"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
         android:id="@+id/autoplay_countdown"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -109,4 +109,9 @@
     <color name="default_background">#CCCCCC</color> <!-- Hellgrau -->
     <color name="default_transparent">#00ffffff</color>
 
+    <!-- Banner colors -->
+    <color name="banner_blue">#8000B0FF</color>
+    <color name="banner_red">#80FF0000</color>
+    <color name="banner_green">#8000FF00</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,9 @@
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
+
+    <!-- Connection banner -->
+    <string name="banner_connecting">connecting…</string>
+    <string name="banner_connected">Connected!</string>
+    <string name="banner_error">Error: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add constant for banner duration
- show connection banner in player overlay
- provide drawables and colors for banner states
- handle playback events in MediaServiceController and PlayerFragment
- adapt StationsFragment to new callback API

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_686a7545e1d0832f9312d39444790891