### PR TITLE
Add connection banner during buffering

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -48,4 +48,6 @@ object Keys {
     const val DEFAULT_RFC2822_DATE: String = "Thu, 01 Jan 1970 01:00:00 +0100" // --> Date(0)
     const val EMPTY_STRING_RESOURCE: Int = 0
 
+    const val CONNECTED_BANNER_DURATION_MS: Long = 1000L
+
 }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -29,7 +30,8 @@ class MediaServiceController(private val context: Context) {
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
         onTimelineChanged: (Int) -> Unit,
-        onPlaybackStateChanged: (Int) -> Unit = {}
+        onPlaybackStateChanged: (Int) -> Unit = {},
+        onPlayerError: (PlaybackException) -> Unit = {}
     ) {
         // Service als Foreground starten
         val serviceIntent = Intent(context, StreamingService::class.java)
@@ -53,6 +55,10 @@ class MediaServiceController(private val context: Context) {
 
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         onPlaybackStateChanged(playbackState)
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        onPlayerError(error)
                     }
 
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -28,7 +28,8 @@ class MediaServiceController(private val context: Context) {
         onPlaybackChanged: (Boolean) -> Unit,
         onStreamIndexChanged: (Int) -> Unit,
         onMetadataChanged: (String) -> Unit,
-        onTimelineChanged: (Int) -> Unit
+        onTimelineChanged: (Int) -> Unit,
+        onPlaybackStateChanged: (Int) -> Unit = {}
     ) {
         // Service als Foreground starten
         val serviceIntent = Intent(context, StreamingService::class.java)
@@ -48,6 +49,10 @@ class MediaServiceController(private val context: Context) {
                 listener = object : Player.Listener {
                     override fun onIsPlayingChanged(isPlaying: Boolean) {
                         onPlaybackChanged(isPlaying)
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        onPlaybackStateChanged(playbackState)
                     }
 
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.BroadcastReceiver
 import android.content.IntentFilter
+import android.content.SharedPreferences
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -66,6 +67,14 @@ class PlayerFragment : Fragment() {
     private var countdownRunnable: Runnable? = null
     private val bannerHandler = Handler(Looper.getMainLooper())
     private var bannerRunnable: Runnable? = null
+    private lateinit var prefs: SharedPreferences
+    private var showInfoBanner: Boolean = true
+    private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { shared, key ->
+        if (key == "show_exoplayer_banner") {
+            showInfoBanner = shared.getBoolean(key, true)
+            if (!showInfoBanner) hideConnecting()
+        }
+    }
 
     private val autoplayReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -122,6 +131,9 @@ class PlayerFragment : Fragment() {
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
         connectingBanner = view.findViewById(R.id.connecting_banner)
+        prefs = requireContext().getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        showInfoBanner = prefs.getBoolean("show_exoplayer_banner", true)
+        prefs.registerOnSharedPreferenceChangeListener(prefsListener)
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -444,6 +456,7 @@ class PlayerFragment : Fragment() {
             requireContext().unregisterReceiver(autoplayReceiver)
             countdownHandler.removeCallbacksAndMessages(null)
             bannerHandler.removeCallbacksAndMessages(null)
+            prefs.unregisterOnSharedPreferenceChangeListener(prefsListener)
             mediaServiceController.disconnect()
         }
         super.onDestroyView()
@@ -484,6 +497,7 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showConnecting() {
+        if (!showInfoBanner) return
         bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
         if (::connectingBanner.isInitialized) {
             connectingBanner.text = getString(R.string.connecting)
@@ -493,6 +507,7 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showConnected() {
+        if (!showInfoBanner) return
         bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
         if (::connectingBanner.isInitialized) {
             connectingBanner.text = getString(R.string.connected)
@@ -504,6 +519,7 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showError(message: String?) {
+        if (!showInfoBanner) return
         bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
         if (::connectingBanner.isInitialized) {
             connectingBanner.text = getString(R.string.playback_error, message ?: "unknown")

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -479,10 +479,14 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showConnecting() {
-        connectingBanner.visibility = View.VISIBLE
+        if (::connectingBanner.isInitialized) {
+            connectingBanner.visibility = View.VISIBLE
+        }
     }
 
     private fun hideConnecting() {
-        connectingBanner.visibility = View.GONE
+        if (::connectingBanner.isInitialized) {
+            connectingBanner.visibility = View.GONE
+        }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -35,6 +35,7 @@ import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
+import androidx.media3.common.Player
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
@@ -60,6 +61,7 @@ class PlayerFragment : Fragment() {
     private lateinit var shortcutRecyclerView: RecyclerView
     private lateinit var shortcutAdapter: ShortcutAdapter
     private lateinit var countdownTextView: TextView
+    private lateinit var connectingBanner: TextView
     private val countdownHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
 
@@ -117,6 +119,7 @@ class PlayerFragment : Fragment() {
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
+        connectingBanner = view.findViewById(R.id.connecting_banner)
 
         // Grundlegende Button-Listener setzen, auch wenn die Playlist leer ist
         playPauseButton.setOnClickListener { mediaServiceController.togglePlayPause() }
@@ -197,6 +200,13 @@ class PlayerFragment : Fragment() {
             onTimelineChanged = {
                 Log.d("PlayerFragment", "\ud83d\udd01 Timeline ge\u00e4ndert! Grund: $it")
                 reloadPlaylist()
+            },
+            onPlaybackStateChanged = { state ->
+                if (state == Player.STATE_BUFFERING) {
+                    showConnecting()
+                } else if (state == Player.STATE_READY) {
+                    hideConnecting()
+                }
             }
         )
 
@@ -466,5 +476,13 @@ class PlayerFragment : Fragment() {
     private fun hideCountdown() {
         countdownRunnable?.let { countdownHandler.removeCallbacks(it) }
         countdownTextView.visibility = View.GONE
+    }
+
+    private fun showConnecting() {
+        connectingBanner.visibility = View.VISIBLE
+    }
+
+    private fun hideConnecting() {
+        connectingBanner.visibility = View.GONE
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -200,7 +200,7 @@ class PlayerFragment : Fragment() {
             },
             onMetadataChanged = {},
             onTimelineChanged = {
-                Log.d("PlayerFragment", "\ud83d\udd01 Timeline ge\u00e4ndert! Grund: $it")
+                Log.d("PlayerFragment", "\uD83D\uDD01 Timeline ge\u00E4ndert! Grund: $it")
                 reloadPlaylist()
             },
             onPlaybackStateChanged = { state ->
@@ -208,6 +208,9 @@ class PlayerFragment : Fragment() {
                     Player.STATE_BUFFERING -> showConnecting()
                     Player.STATE_READY -> showConnected()
                 }
+            },
+            onPlayerError = { error ->
+                showError(error.message)
             }
         )
 
@@ -497,6 +500,15 @@ class PlayerFragment : Fragment() {
             connectingBanner.visibility = View.VISIBLE
             bannerRunnable = Runnable { hideConnecting() }
             bannerHandler.postDelayed(bannerRunnable!!, Keys.CONNECTED_BANNER_DURATION_MS)
+        }
+    }
+
+    private fun showError(message: String?) {
+        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
+        if (::connectingBanner.isInitialized) {
+            connectingBanner.text = getString(R.string.playback_error, message ?: "unknown")
+            connectingBanner.setBackgroundResource(R.drawable.rounded_red_transparent_bg)
+            connectingBanner.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -64,6 +64,8 @@ class PlayerFragment : Fragment() {
     private lateinit var connectingBanner: TextView
     private val countdownHandler = Handler(Looper.getMainLooper())
     private var countdownRunnable: Runnable? = null
+    private val bannerHandler = Handler(Looper.getMainLooper())
+    private var bannerRunnable: Runnable? = null
 
     private val autoplayReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -202,10 +204,9 @@ class PlayerFragment : Fragment() {
                 reloadPlaylist()
             },
             onPlaybackStateChanged = { state ->
-                if (state == Player.STATE_BUFFERING) {
-                    showConnecting()
-                } else if (state == Player.STATE_READY) {
-                    hideConnecting()
+                when (state) {
+                    Player.STATE_BUFFERING -> showConnecting()
+                    Player.STATE_READY -> showConnected()
                 }
             }
         )
@@ -439,6 +440,7 @@ class PlayerFragment : Fragment() {
         if (initialized) {
             requireContext().unregisterReceiver(autoplayReceiver)
             countdownHandler.removeCallbacksAndMessages(null)
+            bannerHandler.removeCallbacksAndMessages(null)
             mediaServiceController.disconnect()
         }
         super.onDestroyView()
@@ -479,12 +481,27 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showConnecting() {
+        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
         if (::connectingBanner.isInitialized) {
+            connectingBanner.text = getString(R.string.connecting)
+            connectingBanner.setBackgroundResource(R.drawable.rounded_blue_transparent_bg)
             connectingBanner.visibility = View.VISIBLE
         }
     }
 
+    private fun showConnected() {
+        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
+        if (::connectingBanner.isInitialized) {
+            connectingBanner.text = getString(R.string.connected)
+            connectingBanner.setBackgroundResource(R.drawable.rounded_green_transparent_bg)
+            connectingBanner.visibility = View.VISIBLE
+            bannerRunnable = Runnable { hideConnecting() }
+            bannerHandler.postDelayed(bannerRunnable!!, Keys.CONNECTED_BANNER_DURATION_MS)
+        }
+    }
+
     private fun hideConnecting() {
+        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
         if (::connectingBanner.isInitialized) {
             connectingBanner.visibility = View.GONE
         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -62,6 +62,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_pip)
     }
 
+    val bannerSwitch = SwitchPreferenceCompat(context).apply {
+        key = "show_exoplayer_banner"
+        title = getString(R.string.settings_exoplayer_infobanner)
+        setDefaultValue(true)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_autoplay)
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -79,7 +87,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
-    val preferences = listOf(autoplaySwitch, delayPreference, minimizeSwitch, versionPref, updatePref)
+    val preferences = listOf(
+        autoplaySwitch,
+        delayPreference,
+        minimizeSwitch,
+        bannerSwitch,
+        versionPref,
+        updatePref
+    )
 
     SettingsCategory.values().forEach { cat ->
         val catPref = categoryMap[cat]!!

--- a/app/src/main/res/drawable/rounded_blue_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_blue_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/connect_banner_connecting_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/rounded_green_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_green_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/connect_banner_connected_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/rounded_red_transparent_bg.xml
+++ b/app/src/main/res/drawable/rounded_red_transparent_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/connect_banner_error_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -38,6 +38,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/connecting_banner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:padding="8dp"
+        android:text="@string/connecting"
+        android:textColor="@android:color/black"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/autoplay_countdown"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Player Buttons -->
     <LinearLayout
         android:id="@+id/player_buttons_group"

--- a/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_player_ui_overlay.xml
@@ -43,7 +43,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:background="@drawable/rounded_blue_transparent_bg"
         android:padding="8dp"
         android:text="@string/connecting"
         android:textColor="@android:color/black"

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -38,6 +38,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/connecting_banner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:padding="8dp"
+        android:text="@string/connecting"
+        android:textColor="@android:color/black"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/autoplay_countdown"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Cover Image -->
 
     <!-- Player Buttons -->

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -43,7 +43,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:background="@drawable/rounded_white_semitransparent_bg"
+        android:background="@drawable/rounded_blue_transparent_bg"
         android:padding="8dp"
         android:text="@string/connecting"
         android:textColor="@android:color/black"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -112,5 +112,6 @@
     <!-- Banner backgrounds -->
     <color name="connect_banner_connecting_bg">#802196F3</color>
     <color name="connect_banner_connected_bg">#804CAF50</color>
+    <color name="connect_banner_error_bg">#80F44336</color>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -109,4 +109,8 @@
     <color name="default_background">#CCCCCC</color> <!-- Hellgrau -->
     <color name="default_transparent">#00ffffff</color>
 
+    <!-- Banner backgrounds -->
+    <color name="connect_banner_connecting_bg">#802196F3</color>
+    <color name="connect_banner_connected_bg">#804CAF50</color>
+
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="connected_banner_duration_ms">1000</integer>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,7 @@
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
+    <string name="settings_exoplayer_infobanner">Show Exoplayer Infobanner</string>
     <string name="connecting">Verbindung wird hergestellt…</string>
     <string name="connected">Connected!</string>
     <string name="playback_error">Error: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,5 @@
     <string name="update_check_fail">Updateprüfung fehlgeschlagen</string>
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
+    <string name="connecting">Verbindung wird hergestellt…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,4 +125,5 @@
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
     <string name="connecting">Verbindung wird hergestellt…</string>
     <string name="connected">Connected!</string>
+    <string name="playback_error">Error: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,5 @@
     <string name="minimizing_in">Minimizing in %1$d s</string>
     <string name="no_metadata_available">Keine Informationen verfügbar</string>
     <string name="connecting">Verbindung wird hergestellt…</string>
+    <string name="connected">Connected!</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `connecting_banner` TextView in player overlay
- show banner while ExoPlayer buffers
- hide banner once ready
- extend `MediaServiceController` with playback state callback

## Testing
- `./gradlew assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a790375a0832f8b33d52ee7044d9f