### PR TITLE
Highlight update notification

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -1,6 +1,9 @@
 package at.plankt0n.streamplay.ui
 
 import android.content.Context
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import androidx.preference.*
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.Keys
@@ -86,7 +89,18 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         title = getString(R.string.settings_check_updates)
         val updateAvailable = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
             .getBoolean(Keys.PREF_UPDATE_AVAILABLE, false)
-        summary = if (updateAvailable) context.getString(R.string.update_available_title) else null
+        summary = if (updateAvailable) {
+            val text = context.getString(R.string.update_available_title)
+            val color = context.getColor(R.color.update_available_orange)
+            SpannableString(text).apply {
+                setSpan(
+                    ForegroundColorSpan(color),
+                    0,
+                    text.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            }
+        } else null
         category = SettingsCategory.ABOUT
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
@@ -15,7 +18,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
         if (key == Keys.PREF_UPDATE_AVAILABLE) {
             val pref = findPreference<Preference>("check_updates")
             val show = shared.getBoolean(key, false)
-            pref?.summary = if (show) getString(R.string.update_available_title) else null
+            pref?.summary = if (show) {
+                val text = getString(R.string.update_available_title)
+                val color = requireContext().getColor(R.color.update_available_orange)
+                SpannableString(text).apply {
+                    setSpan(
+                        ForegroundColorSpan(color),
+                        0,
+                        text.length,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+            } else null
         }
     }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -113,5 +113,7 @@
     <color name="connect_banner_connecting_bg">#802196F3</color>
     <color name="connect_banner_connected_bg">#804CAF50</color>
     <color name="connect_banner_error_bg">#80F44336</color>
+    <!-- Color for update available text -->
+    <color name="update_available_orange">#FFA500</color>
 
 </resources>


### PR DESCRIPTION
## Summary
- highlight update notice in orange
- update settings listeners to apply custom color
- add orange color resource

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa12da50c832f87f42aa4230f5637