### PR TITLE
Implement manual log feature

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
@@ -1,10 +1,12 @@
 package at.plankt0n.streamplay.adapter
 
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.MetaLogEntry
@@ -39,6 +41,13 @@ class MetaLogAdapter(
         val item = items[position]
         holder.line1.text = "${item.formattedTime()} - ${item.station}"
         holder.line2.text = "${item.title} - ${item.artist}"
+        if (item.manual) {
+            holder.itemView.setBackgroundColor(
+                ContextCompat.getColor(holder.itemView.context, R.color.highlight)
+            )
+        } else {
+            holder.itemView.setBackgroundColor(Color.TRANSPARENT)
+        }
         if (!item.url.isNullOrBlank()) {
             holder.button.visibility = View.VISIBLE
             holder.button.setOnClickListener { onUrlClick(item.url!!) }

--- a/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
@@ -9,7 +9,8 @@ data class MetaLogEntry(
     val station: String,
     val title: String,
     val artist: String,
-    val url: String? = null
+    val url: String? = null,
+    val manual: Boolean = false
 ) {
     fun formattedTime(): String {
         val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
@@ -15,6 +15,22 @@ object MetaLogHelper {
 
     fun addLog(context: Context, entry: MetaLogEntry) {
         val list = getLogs(context)
+
+        if (list.isNotEmpty()) {
+            val newest = list[0]
+            val sameMeta = newest.station == entry.station &&
+                newest.title == entry.title &&
+                newest.artist == entry.artist &&
+                newest.url == entry.url
+
+            if (sameMeta && entry.manual && !newest.manual) {
+                list[0] = entry
+                val json = Gson().toJson(list)
+                prefs(context).edit().putString(KEY_LOGS, json).apply()
+                return
+            }
+        }
+
         list.add(0, entry) // newest first
         val json = Gson().toJson(list)
         prefs(context).edit().putString(KEY_LOGS, json).apply()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.CheckBox
 import android.widget.ImageButton
 import android.text.Editable
 import android.text.TextWatcher
@@ -22,6 +23,8 @@ import at.plankt0n.streamplay.helper.MetaLogHelper
 class MetaLogFragment : Fragment() {
     private lateinit var adapter: MetaLogAdapter
     private lateinit var searchField: EditText
+    private lateinit var manualFilter: CheckBox
+    private var showManualOnly = false
     private var allLogs = mutableListOf<MetaLogEntry>()
 
     override fun onCreateView(
@@ -48,6 +51,11 @@ class MetaLogFragment : Fragment() {
         recycler.adapter = adapter
 
         searchField = view.findViewById(R.id.editSearchLogs)
+        manualFilter = view.findViewById(R.id.checkManualFilter)
+        manualFilter.setOnCheckedChangeListener { _, isChecked ->
+            showManualOnly = isChecked
+            filterLogs(searchField.text.toString())
+        }
         searchField.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
@@ -70,16 +78,16 @@ class MetaLogFragment : Fragment() {
     }
 
     private fun filterLogs(query: String) {
-        if (query.isBlank()) {
-            adapter.setItems(allLogs)
-            return
-        }
         val lower = query.lowercase()
         val filtered = allLogs.filter {
-            it.station.contains(lower, true) ||
-            it.title.contains(lower, true) ||
-            it.artist.contains(lower, true) ||
-            it.formattedTime().contains(lower, true)
+            val matchesQuery = if (query.isBlank()) true else (
+                it.station.contains(lower, true) ||
+                it.title.contains(lower, true) ||
+                it.artist.contains(lower, true) ||
+                it.formattedTime().contains(lower, true)
+            )
+            val manualOk = !showManualOnly || it.manual
+            matchesQuery && manualOk
         }
         adapter.setItems(filtered)
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -34,12 +34,15 @@ import at.plankt0n.streamplay.helper.LiveCoverHelper
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.helper.MetaLogHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.Keys
+import at.plankt0n.streamplay.data.MetaLogEntry
 import androidx.media3.common.Player
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
+import android.widget.Toast
 
 class PlayerFragment : Fragment() {
 
@@ -58,6 +61,7 @@ class PlayerFragment : Fragment() {
     private lateinit var buttonMenu: ImageButton
     private lateinit var updateBadge: TextView
     private lateinit var buttonSpotify: ImageButton
+    private lateinit var buttonManualLog: ImageButton
     private lateinit var buttonMute: ImageButton
     private lateinit var buttonShare: ImageButton
     private lateinit var shortcutRecyclerView: RecyclerView
@@ -133,6 +137,7 @@ class PlayerFragment : Fragment() {
         buttonBack = view.findViewById(R.id.button_back)
         buttonForward = view.findViewById(R.id.button_forward)
         buttonSpotify = view.findViewById(R.id.button_spotify)
+        buttonManualLog = view.findViewById(R.id.button_manual_log)
         buttonMute = view.findViewById(R.id.button_mute_unmute)
         buttonShare = view.findViewById(R.id.button_share)
         countdownTextView = view.findViewById(R.id.autoplay_countdown)
@@ -269,6 +274,8 @@ class PlayerFragment : Fragment() {
 
             startActivity(Intent.createChooser(intent, chooserTitle))
         }
+
+        buttonManualLog.setOnClickListener { addManualLog() }
 
         buttonMute.setOnClickListener {
             val audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -533,6 +540,26 @@ class PlayerFragment : Fragment() {
             connectingBanner.setBackgroundResource(R.drawable.rounded_red_transparent_bg)
             connectingBanner.visibility = View.VISIBLE
         }
+    }
+
+    private fun addManualLog() {
+        val trackInfo = spotifyTrackViewModel.trackInfo.value ?: return
+        val controller = mediaServiceController.mediaController ?: return
+        val stationName = controller.getMediaItemAt(viewPager.currentItem)
+            .mediaMetadata.extras?.getString("EXTRA_STATION_NAME") ?: ""
+
+        MetaLogHelper.addLog(
+            requireContext(),
+            MetaLogEntry(
+                timestamp = System.currentTimeMillis(),
+                station = stationName,
+                title = trackInfo.trackName,
+                artist = trackInfo.artistName,
+                url = trackInfo.spotifyUrl.takeIf { it.isNotBlank() },
+                manual = true
+            )
+        )
+        Toast.makeText(requireContext(), getString(R.string.manual_log_saved), Toast.LENGTH_SHORT).show()
     }
 
     private fun hideConnecting() {

--- a/app/src/main/res/layout/fragment_meta_log.xml
+++ b/app/src/main/res/layout/fragment_meta_log.xml
@@ -13,6 +13,12 @@
         android:hint="@string/search_logs_hint"
         android:padding="8dp" />
 
+    <CheckBox
+        android:id="@+id/checkManualFilter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/filter_manual_logs" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerMetaLog"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <!-- Meta log -->
     <string name="search_logs_hint">Search logs</string>
     <string name="clear_logs">Clear Logs</string>
+    <string name="filter_manual_logs">Show only manual logs</string>
+    <string name="manual_log_saved">Manual log saved</string>
 
     <string name="drag_handle_desc">Move station</string>
 


### PR DESCRIPTION
## Summary
- add `manual` flag to `MetaLogEntry`
- highlight manual logs in log list
- add checkbox filter for manual logs
- allow manual logging from player UI
- add new strings for manual logging

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab505cc04832faf0aae66571aa806