### PR TITLE
Add switchable background effects

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
@@ -13,12 +13,14 @@ import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.MediaServiceController
+import at.plankt0n.streamplay.helper.LiveCoverHelper
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.BitmapImageViewTarget
 import com.google.android.material.imageview.ShapeableImageView
 
 class CoverPageAdapter(
-    private val mediaServiceController: MediaServiceController
+    private val mediaServiceController: MediaServiceController,
+    private val backgroundEffect: LiveCoverHelper.BackgroundEffect
 ) : RecyclerView.Adapter<CoverPageAdapter.CoverViewHolder>() {
 
     val mediaItems: List<StationItem> = mediaServiceController.getCurrentPlaylist()
@@ -67,12 +69,7 @@ class CoverPageAdapter(
                                     animator.duration = 400
                                     animator.addUpdateListener { a ->
                                         val color = a.animatedValue as Int
-                                        // Verlauf erzeugen: oben deckend, unten transparent
-                                        val gradient = GradientDrawable(
-                                            GradientDrawable.Orientation.TOP_BOTTOM,
-                                            intArrayOf(color, Color.TRANSPARENT)
-                                        )
-                                        gradient.cornerRadius = 0f
+                                        val gradient = LiveCoverHelper.createGradient(color, backgroundEffect)
                                         holder.itemView.background = gradient
                                     }
                                     animator.start()

--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -14,13 +14,16 @@ import androidx.palette.graphics.Palette
 
 object LiveCoverHelper {
 
-    fun loadCoverWithBackgroundFade(
+    enum class BackgroundEffect { FADE, AQUA, RADIAL }
+
+    fun loadCoverWithBackground(
         context: Context,
         imageUrl: String,
         imageView: ImageView,
         backgroundTarget: View,
         defaultColor: Int,
         lastColor: Int?,
+        effect: BackgroundEffect = BackgroundEffect.FADE,
         onNewColor: (Int) -> Unit
     ) {
         Glide.with(context)
@@ -51,11 +54,7 @@ object LiveCoverHelper {
                                         duration = 400
                                         addUpdateListener { anim ->
                                             val color = anim.animatedValue as Int
-                                            val gradient = GradientDrawable(
-                                                GradientDrawable.Orientation.TOP_BOTTOM,
-                                                intArrayOf(color, Color.TRANSPARENT)
-                                            )
-                                            gradient.cornerRadius = 0f
+                                            val gradient = createGradient(color, effect)
                                             backgroundTarget.background = gradient
                                         }
                                     }
@@ -67,5 +66,23 @@ object LiveCoverHelper {
                     }
                 }
             })
+    }
+
+    fun createGradient(color: Int, effect: BackgroundEffect): GradientDrawable {
+        return when (effect) {
+            BackgroundEffect.FADE -> GradientDrawable(
+                GradientDrawable.Orientation.TOP_BOTTOM,
+                intArrayOf(color, Color.TRANSPARENT)
+            )
+            BackgroundEffect.AQUA -> GradientDrawable(
+                GradientDrawable.Orientation.BL_TR,
+                intArrayOf(Color.parseColor("#00d4ff"), Color.TRANSPARENT)
+            )
+            BackgroundEffect.RADIAL -> GradientDrawable().apply {
+                gradientType = GradientDrawable.RADIAL_GRADIENT
+                colors = intArrayOf(color, Color.TRANSPARENT)
+                gradientRadius = 800f
+            }
+        }.apply { cornerRadius = 0f }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -70,10 +70,18 @@ class PlayerFragment : Fragment() {
     private var bannerRunnable: Runnable? = null
     private lateinit var prefs: SharedPreferences
     private var showInfoBanner: Boolean = true
+    private var backgroundEffect = LiveCoverHelper.BackgroundEffect.FADE
     private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { shared, key ->
         if (key == "show_exoplayer_banner") {
             showInfoBanner = shared.getBoolean(key, true)
             if (!showInfoBanner) hideConnecting()
+        }
+        if (key == "background_effect") {
+            backgroundEffect = try {
+                LiveCoverHelper.BackgroundEffect.valueOf(shared.getString(key, LiveCoverHelper.BackgroundEffect.FADE.name)!!)
+            } catch (e: IllegalArgumentException) {
+                LiveCoverHelper.BackgroundEffect.FADE
+            }
         }
         if (key == Keys.PREF_UPDATE_AVAILABLE) {
             val showBadge = shared.getBoolean(key, false)
@@ -139,6 +147,13 @@ class PlayerFragment : Fragment() {
         connectingBanner = view.findViewById(R.id.connecting_banner)
         prefs = requireContext().getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
         showInfoBanner = prefs.getBoolean("show_exoplayer_banner", true)
+        backgroundEffect = try {
+            LiveCoverHelper.BackgroundEffect.valueOf(
+                prefs.getString("background_effect", LiveCoverHelper.BackgroundEffect.FADE.name)!!
+            )
+        } catch (e: IllegalArgumentException) {
+            LiveCoverHelper.BackgroundEffect.FADE
+        }
         updateBadge.visibility = if (prefs.getBoolean(Keys.PREF_UPDATE_AVAILABLE, false)) View.VISIBLE else View.GONE
         prefs.registerOnSharedPreferenceChangeListener(prefsListener)
 
@@ -189,7 +204,7 @@ class PlayerFragment : Fragment() {
                     StateHelper.hasAutoOpenedDiscover = false
                 }
 
-                val coverPageAdapter = CoverPageAdapter(mediaServiceController)
+                val coverPageAdapter = CoverPageAdapter(mediaServiceController, backgroundEffect)
                 viewPager.adapter = coverPageAdapter
                 dotsIndicator.setViewPager2(viewPager)
 
@@ -344,13 +359,14 @@ class PlayerFragment : Fragment() {
             val metaCoverUrl = trackInfo.bestCoverUrl?.takeIf { it.isNotBlank() }
             val imageUrlToLoad = metaCoverUrl ?: defaultIconUrl
 
-            LiveCoverHelper.loadCoverWithBackgroundFade(
+            LiveCoverHelper.loadCoverWithBackground(
                 context = requireContext(),
                 imageUrl = imageUrlToLoad,
                 imageView = holder.coverImage,
                 backgroundTarget = holder.itemView,
                 defaultColor = requireContext().getColor(R.color.default_background),
                 lastColor = holder.lastColor,
+                effect = backgroundEffect,
                 onNewColor = { holder.lastColor = it }
             )
 
@@ -361,13 +377,14 @@ class PlayerFragment : Fragment() {
                     .rotationY(90f)
                     .setDuration(150)
                     .withEndAction {
-                        LiveCoverHelper.loadCoverWithBackgroundFade(
+                        LiveCoverHelper.loadCoverWithBackground(
                             context = requireContext(),
                             imageUrl = targetUrl,
                             imageView = holder.coverImage,
                             backgroundTarget = holder.itemView,
                             defaultColor = requireContext().getColor(R.color.default_background),
                             lastColor = holder.lastColor,
+                            effect = backgroundEffect,
                             onNewColor = { holder.lastColor = it }
                         )
                         holder.coverImage.rotationY = -90f
@@ -445,7 +462,7 @@ class PlayerFragment : Fragment() {
         }
         shortcutAdapter.setItems(shortcuts)
 
-        val coverPageAdapter = CoverPageAdapter(mediaServiceController)
+        val coverPageAdapter = CoverPageAdapter(mediaServiceController, backgroundEffect)
         viewPager.adapter = coverPageAdapter
         dotsIndicator.setViewPager2(viewPager)
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -7,6 +7,7 @@ import android.text.style.ForegroundColorSpan
 import androidx.preference.*
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.Keys
+import at.plankt0n.streamplay.helper.LiveCoverHelper
 
 /** Possible categories a preference can belong to. */
 enum class SettingsCategory { PLAYBACK, UI, METAINFO, ABOUT }
@@ -75,6 +76,24 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
+    val backgroundEffectPref = ListPreference(context).apply {
+        key = "background_effect"
+        title = getString(R.string.settings_background_effect)
+        entries = arrayOf(
+            getString(R.string.bg_effect_fade),
+            getString(R.string.bg_effect_aqua),
+            getString(R.string.bg_effect_radial)
+        )
+        entryValues = arrayOf(
+            LiveCoverHelper.BackgroundEffect.FADE.name,
+            LiveCoverHelper.BackgroundEffect.AQUA.name,
+            LiveCoverHelper.BackgroundEffect.RADIAL.name
+        )
+        setDefaultValue(LiveCoverHelper.BackgroundEffect.FADE.name)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -110,6 +129,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         delayPreference,
         minimizeSwitch,
         bannerSwitch,
+        backgroundEffectPref,
         versionPref,
         updatePref
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,4 +127,8 @@
     <string name="connecting">Verbindung wird hergestellt…</string>
     <string name="connected">Connected!</string>
     <string name="playback_error">Error: %1$s</string>
+    <string name="settings_background_effect">Background Effect</string>
+    <string name="bg_effect_fade">Fade</string>
+    <string name="bg_effect_aqua">Aqua</string>
+    <string name="bg_effect_radial">Radial</string>
 </resources>


### PR DESCRIPTION
## Summary
- expand LiveCoverHelper with effect variants
- update PlayerFragment and CoverPageAdapter to use selected effect
- add setting to choose effect
- provide strings for effect names

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac0878404832f9c45461e7b18ca78