### PR TITLE
Fix track ViewModel reuse across fragments

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -10,6 +10,7 @@ object Keys {
     const val PREF_UPDATE_AVAILABLE = "update_available"
     const val ACTION_SHOW_COUNTDOWN = "at.plankt0n.streamplay.SHOW_COUNTDOWN"
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
+    const val ACTION_REFRESH_METADATA = "at.plankt0n.streamplay.ACTION_REFRESH_METADATA"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
     const val UPDATE_FORCE_TAP_COUNT = 5
 

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -40,7 +40,7 @@ import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.SpotifyMetaReader
 import at.plankt0n.streamplay.helper.MetaLogHelper
 import at.plankt0n.streamplay.data.MetaLogEntry
-import at.plankt0n.streamplay.viewmodel.UITrackViewModel
+import at.plankt0n.streamplay.viewmodel.UITrackRepository
 import at.plankt0n.streamplay.viewmodel.UITrackInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -125,7 +125,7 @@ class StreamingService : MediaSessionService() {
                         currentIndex = currentMediaItemIndex
 
                         Log.d("StreamingService", "💾 Index gespeichert: $currentIndex")
-                        UITrackViewModel.clearTrackInfo()
+                        UITrackRepository.clearTrackInfo()
 
 
                         PreferencesHelper.setLastPlayedStreamIndex(
@@ -377,7 +377,7 @@ class StreamingService : MediaSessionService() {
                         )
 
 
-                        UITrackViewModel.updateTrackInfo(
+                        UITrackRepository.updateTrackInfo(
                             UITrackInfo(
                                 trackName = extendedInfo.trackName,
                                 artistName = extendedInfo.artistName,
@@ -413,7 +413,7 @@ class StreamingService : MediaSessionService() {
                             "❌ Keine Spotify-Daten gefunden für: $artist - $title"
                         )
                         updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
-                        UITrackViewModel.updateTrackInfo(
+                        UITrackRepository.updateTrackInfo(
                             UITrackInfo(
                                 trackName = title,
                                 artistName = artist,
@@ -442,7 +442,7 @@ class StreamingService : MediaSessionService() {
             GlobalScope.launch(Dispatchers.Main) {
                 updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
             }
-            UITrackViewModel.updateTrackInfo(
+            UITrackRepository.updateTrackInfo(
                 UITrackInfo(
                     trackName = title,
                     artistName = artist,

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -88,8 +88,9 @@ class StreamingService : MediaSessionService() {
 
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST") {
-            refreshPlaylist()
+        when (intent?.action) {
+            "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST" -> refreshPlaylist()
+            Keys.ACTION_REFRESH_METADATA -> refreshMediaItemMetadata()
         }
         return super.onStartCommand(intent, flags, startId)
     }
@@ -506,15 +507,13 @@ class StreamingService : MediaSessionService() {
 
 
     fun refreshMediaItemMetadata() {
-
-    val refreshMetaData = lastshowedMetadata
+        val refreshMetaData = lastshowedMetadata
         val isInForeground = isAppInForeground()
-
 
         val updateartist: String
         var updatetitle: String
-val artist = refreshMetaData?.artist?.toString().orEmpty()
-val title = refreshMetaData?.title?.toString().orEmpty()
+        val artist = refreshMetaData?.artist?.toString().orEmpty()
+        val title = refreshMetaData?.title?.toString().orEmpty()
         val artworkUri = refreshMetaData?.artworkUri?.toString().orEmpty()
 
         if (isInForeground) {
@@ -546,6 +545,14 @@ val title = refreshMetaData?.title?.toString().orEmpty()
             player.replaceMediaItem(player.currentMediaItemIndex, updatedMediaItem)
             Log.d("StreamingService", "🔄 Nur Metadaten aktualisiert: $title - $artist")
             lastshowedMetadata = updatedMetadata // 🟢 Hier speichern!
+            UITrackRepository.updateTrackInfo(
+                UITrackInfo(
+                    trackName = title,
+                    artistName = artist,
+                    bestCoverUrl = artworkUri
+                )
+            )
+
 
         }
     } //zur anpassung wenn PlayerFragment Minimiert ist damit der sende rin der Medaisesion angzeigt wird

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -8,6 +8,7 @@ import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Handler
+import at.plankt0n.streamplay.StreamingService
 import android.os.Looper
 import android.media.AudioManager
 import android.net.Uri
@@ -237,6 +238,11 @@ class PlayerFragment : Fragment() {
                 updateOverlayUI(currentIndex)
                 updatePlayPauseIcon(controller.isPlaying)
 
+                requireContext().startService(
+                    Intent(requireContext(), StreamingService::class.java).apply {
+                        action = Keys.ACTION_REFRESH_METADATA
+                    }
+                )
                 viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
                     override fun onPageSelected(position: Int) {
                         super.onPageSelected(position)

--- a/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
@@ -16,8 +16,12 @@ data class UITrackInfo(
     val spotifyUrl: String = ""
 )
 
-object  UITrackViewModel : ViewModel() {
-
+/**
+ * Repository object that stores the currently fetched Spotify track information.
+ * This object can be accessed from anywhere in the app, including the
+ * [StreamingService]. The [UITrackViewModel] simply exposes the data held here.
+ */
+object UITrackRepository {
     private val _trackInfo = MutableLiveData<UITrackInfo?>()
     val trackInfo: LiveData<UITrackInfo?> get() = _trackInfo
 
@@ -29,4 +33,15 @@ object  UITrackViewModel : ViewModel() {
         _trackInfo.postValue(null)
         Log.d("UITrackinfo", "Trackinfo cleared")
     }
+}
+
+/**
+ * ViewModel used by UI components to observe changes in [UITrackRepository].
+ */
+class UITrackViewModel : ViewModel() {
+    val trackInfo: LiveData<UITrackInfo?> = UITrackRepository.trackInfo
+
+    fun updateTrackInfo(info: UITrackInfo) = UITrackRepository.updateTrackInfo(info)
+
+    fun clearTrackInfo() = UITrackRepository.clearTrackInfo()
 }


### PR DESCRIPTION
## Summary
- keep track info in `UITrackRepository`
- convert `UITrackViewModel` to a class that exposes the repository
- update `StreamingService` to use `UITrackRepository`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad32bc1a4832f826a9a32def88bc2