### PR TITLE
Fix metadata clearing on stream switch

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -127,6 +127,9 @@ class StreamingService : MediaSessionService() {
 
                         Log.d("StreamingService", "💾 Index gespeichert: $currentIndex")
                         UITrackRepository.clearTrackInfo()
+                        lastIcyMetadata = null
+                        lastshowedMetadata = null
+                        lastArtworkUri = null
 
 
                         PreferencesHelper.setLastPlayedStreamIndex(


### PR DESCRIPTION
## Summary
- reset metadata variables when the player switches stations

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b625527a4832fa0a4f2f660e1db77