### PR TITLE
Remove local updateinfo JSON

### DIFF
--- a/updateinfo.json
+++ b/updateinfo.json
@@ -1,4 +1,0 @@
-{
-  "version": "1.0.3",
-  "apkUrl": "https://fytfiles.printspace.at/update/streamplay.apk"
-}


### PR DESCRIPTION
## Summary
- remove `updateinfo.json` as updates are now provided via GitHub

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b686e66dc832fbe76df112e4bbdec