### PR TITLE
Fix outdated metadata after station switch

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -128,10 +128,13 @@ class StreamingService : MediaSessionService() {
 
                         Log.d("StreamingService", "💾 Index gespeichert: $currentIndex")
                         currentStationUuid = mediaItem?.mediaMetadata?.extras?.getString("EXTRA_UUID")
+                        val fallbackartworkUri = mediaItem?.mediaMetadata?.extras?.getString("EXTRA_ICON_URL") ?: ""
                         UITrackRepository.clearTrackInfo()
                         lastIcyMetadata = null
                         lastshowedMetadata = null
                         lastArtworkUri = null
+
+                        updateMediaItemMetadata("", "", fallbackartworkUri)
 
 
                         PreferencesHelper.setLastPlayedStreamIndex(
@@ -381,6 +384,7 @@ class StreamingService : MediaSessionService() {
                 withContext(Dispatchers.Main) {
                     if (stationUuidAtFetchStart != currentStationUuid) {
                         Log.d("StreamingService", "ℹ️ Station changed during metadata fetch, ignoring results")
+                        updateMediaItemMetadata("", "", fallbackartworkUri ?: "")
                         return@withContext
                     }
                     if (extendedInfo != null) {
@@ -453,7 +457,10 @@ class StreamingService : MediaSessionService() {
             )
             // Sicherstellen, dass auch dieser Aufruf im Main-Thread läuft!
             GlobalScope.launch(Dispatchers.Main) {
-                if (stationUuidAtFetchStart != currentStationUuid) return@launch
+                if (stationUuidAtFetchStart != currentStationUuid) {
+                    updateMediaItemMetadata("", "", fallbackartworkUri ?: "")
+                    return@launch
+                }
                 updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
             }
             UITrackRepository.updateTrackInfo(

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -64,6 +64,7 @@ class StreamingService : MediaSessionService() {
     var lastIcyMetadata: Metadata? = null
     private var lastshowedMetadata: MediaMetadata? = null
     private var lastArtworkUri: String? = null
+    private var currentStationUuid: String? = null
 
     companion object {
         const val CHANNEL_ID = "stream_service_channel"
@@ -126,6 +127,7 @@ class StreamingService : MediaSessionService() {
                         currentIndex = currentMediaItemIndex
 
                         Log.d("StreamingService", "💾 Index gespeichert: $currentIndex")
+                        currentStationUuid = mediaItem?.mediaMetadata?.extras?.getString("EXTRA_UUID")
                         UITrackRepository.clearTrackInfo()
                         lastIcyMetadata = null
                         lastshowedMetadata = null
@@ -224,6 +226,7 @@ class StreamingService : MediaSessionService() {
         }
 
         player.setMediaItems(mediaItems, currentIndex, 0L)
+        currentStationUuid = mediaItems[currentIndex].mediaMetadata.extras?.getString("EXTRA_UUID")
         player.prepare()
         maybeAutoplay()
     }
@@ -262,6 +265,7 @@ class StreamingService : MediaSessionService() {
         }
 
         player.setMediaItems(mediaItems, currentIndex, 0L)
+        currentStationUuid = mediaItems[currentIndex].mediaMetadata.extras?.getString("EXTRA_UUID")
         player.prepare()
         maybeAutoplay(wasPlaying)
 
@@ -323,6 +327,7 @@ class StreamingService : MediaSessionService() {
 
     fun fetchMetadata(metadata: Metadata) {
 
+        val stationUuidAtFetchStart = currentStationUuid
         val fallbackartworkUri = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_ICON_URL")
         var title = ""
         var artist = ""
@@ -374,6 +379,10 @@ class StreamingService : MediaSessionService() {
                 val extendedInfo =
                     SpotifyMetaReader.getExtendedMetaInfo(this@StreamingService, artist, title)
                 withContext(Dispatchers.Main) {
+                    if (stationUuidAtFetchStart != currentStationUuid) {
+                        Log.d("StreamingService", "ℹ️ Station changed during metadata fetch, ignoring results")
+                        return@withContext
+                    }
                     if (extendedInfo != null) {
                         Log.d(
                             "SpotifyMetaReader",
@@ -444,6 +453,7 @@ class StreamingService : MediaSessionService() {
             )
             // Sicherstellen, dass auch dieser Aufruf im Main-Thread läuft!
             GlobalScope.launch(Dispatchers.Main) {
+                if (stationUuidAtFetchStart != currentStationUuid) return@launch
                 updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
             }
             UITrackRepository.updateTrackInfo(


### PR DESCRIPTION
## Summary
- track the current station's UUID in `StreamingService`
- update this UUID on playlist changes
- ignore metadata updates that complete after switching stations

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b74948710832fb056a9ba1a0bf8f9