### PR TITLE
Add preview URL and genre display

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -390,7 +390,9 @@ class StreamingService : MediaSessionService() {
                                 durationMs = extendedInfo.durationMs,
                                 albumReleaseDate = extendedInfo.albumReleaseDate,
                                 popularity = extendedInfo.popularity,
-                                spotifyUrl = extendedInfo.spotifyUrl
+                                spotifyUrl = extendedInfo.spotifyUrl,
+                                previewUrl = extendedInfo.previewUrl,
+                                genre = extendedInfo.genre
                             )
                         )
 

--- a/app/src/main/java/at/plankt0n/streamplay/data/ExtendetMetaInfo.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/data/ExtendetMetaInfo.kt
@@ -8,5 +8,7 @@ data class ExtendedMetaInfo(
     val spotifyUrl: String,
     val bestCoverUrl: String?,
     val durationMs: Long,
-    val popularity: Int
+    val popularity: Int,
+    val previewUrl: String = "",
+    val genre: String = ""
 )

--- a/app/src/main/java/at/plankt0n/streamplay/helper/SpotifyMetaReader.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/SpotifyMetaReader.kt
@@ -131,6 +131,7 @@ object SpotifyMetaReader {
             val trackId = trackItem.getString("id")
             val trackUri = trackItem.getJSONObject("external_urls").getString("spotify")
             val trackName = trackItem.getString("name")
+            val previewUrl = trackItem.optString("preview_url", "")
             val trackPopularity = trackItem.getInt("popularity")
             val trackDurationMs = trackItem.getLong("duration_ms")
             val album = trackItem.getJSONObject("album")
@@ -157,9 +158,35 @@ object SpotifyMetaReader {
                 null
             }
 
+            // Genre ermitteln
+            val artistId = trackItem.getJSONArray("artists").optJSONObject(0)?.getString("id")
+            val genre = if (!artistId.isNullOrBlank()) {
+                val artistUrl = "https://api.spotify.com/v1/artists/$artistId"
+                val artistRequest = Request.Builder()
+                    .url(artistUrl)
+                    .header("Authorization", "Bearer $token")
+                    .build()
+
+                client.newCall(artistRequest).execute().use { artistResponse ->
+                    if (artistResponse.isSuccessful) {
+                        val artistJson = JSONObject(artistResponse.body?.string() ?: "")
+                        val genres = artistJson.getJSONArray("genres")
+                        if (genres.length() > 0) genres.getString(0) else ""
+                    } else {
+                        Log.w("SpotifyMetaReader", "⚠️ Spotify Artist API-Fehler: ${artistResponse.code}")
+                        ""
+                    }
+                }
+            } else {
+                ""
+            }
+
+            Log.d("SpotifyMetaReader", "📄 PreviewUrl=$previewUrl | Genre=$genre")
+
             return@withContext ExtendedMetaInfo(
                 trackName, artist, albumName, albumReleaseDate,
-                trackUri, bestAlbumCoverUrl ?: bestCoverUrl, trackDurationMs, trackPopularity
+                trackUri, bestAlbumCoverUrl ?: bestCoverUrl, trackDurationMs, trackPopularity,
+                previewUrl, genre
             )
         }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -357,6 +357,7 @@ class PlayerFragment : Fragment() {
             val flipper = view?.findViewById<ViewFlipper>(R.id.meta_flipper)
             val titleTextView = view?.findViewById<TextView>(R.id.meta_overlay_Title)
             val artistTextView = view?.findViewById<TextView>(R.id.meta_overlay_Artist)
+            val genreTextView = view?.findViewById<TextView>(R.id.meta_overlay_Genre)
             val albumTextView = view?.findViewById<TextView>(R.id.meta_overlay_Album)
             val stationIconView = view?.findViewById<ShapeableImageView>(R.id.meta_cover_image)
 
@@ -372,6 +373,7 @@ class PlayerFragment : Fragment() {
             if (trackInfo == null) {
                 titleTextView?.text = getString(R.string.unknown_title)
                 artistTextView?.text = getString(R.string.unknown_artist)
+                genreTextView?.text = getString(R.string.unknown_genre)
                 albumTextView?.text = getString(R.string.unknown_album)
                 flipper?.stopFlipping()
                 flipper?.setDisplayedChild(0)
@@ -444,6 +446,7 @@ class PlayerFragment : Fragment() {
 
             titleTextView?.text = trackInfo.trackName.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_title)
             artistTextView?.text = trackInfo.artistName.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_artist)
+            genreTextView?.text = trackInfo.genre.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_genre)
 
             if (trackInfo.albumName.isNotBlank()) {
                 albumTextView?.text = getString(R.string.album_prefix, trackInfo.albumName)
@@ -469,7 +472,7 @@ class PlayerFragment : Fragment() {
                     .into(stationIconView!!)
             }
 
-            enableMarquee(titleTextView!!, artistTextView!!, albumTextView!!)
+            enableMarquee(titleTextView!!, artistTextView!!, genreTextView!!, albumTextView!!)
             updateManualLogButtonState(trackInfo)
         }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
@@ -13,7 +13,9 @@ data class UITrackInfo(
     val durationMs: Long = 0L,
     val albumReleaseDate: String = "",
     val popularity: Int = 0,
-    val spotifyUrl: String = ""
+    val spotifyUrl: String = "",
+    val previewUrl: String = "",
+    val genre: String = ""
 )
 
 /**

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -334,6 +334,21 @@
                             android:focusable="false"
                             android:focusableInTouchMode="false"
                             android:scrollHorizontally="true" />
+
+                        <TextView
+                            android:id="@+id/meta_overlay_Genre"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/primary_text_default_material_dark"
+                            android:text="@string/unknown_genre"
+                            android:textSize="12sp"
+                            android:maxLines="1"
+                            android:ellipsize="marquee"
+                            android:marqueeRepeatLimit="marquee_forever"
+                            android:singleLine="true"
+                            android:focusable="false"
+                            android:focusableInTouchMode="false"
+                            android:scrollHorizontally="true" />
                     </LinearLayout>
 
                     <!-- Seite 2: Kombinierter Text -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <!-- Player Fragment -->
     <string name="unknown_title">No Title Information</string>
     <string name="unknown_artist">No Artist Information</string>
+    <string name="unknown_genre">Unknown Genre</string>
     <string name="unknown_station">Unknown Statio</string>
     <string name="unknown_album">Unknown Album</string>
     <string name="album_prefix">Album: %1$s</string>


### PR DESCRIPTION
## Summary
- expand `ExtendedMetaInfo` and `UITrackInfo` with `previewUrl` and `genre`
- fetch preview URLs and genres in `SpotifyMetaReader`
- pass the new fields through `StreamingService`
- show genre next to title/artist in the player UI
- add missing string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baa32a39c832fa9de6c3c26aa2de2