### PR TITLE
Add preview URL logging and playback

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -423,7 +423,8 @@ class StreamingService : MediaSessionService() {
                                 station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
                                 title = extendedInfo.trackName,
                                 artist = extendedInfo.artistName,
-                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() }
+                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() },
+                                previewUrl = extendedInfo.previewUrl
                             )
                         )
                     } else {
@@ -448,7 +449,8 @@ class StreamingService : MediaSessionService() {
                                 station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
                                 title = title,
                                 artist = artist,
-                                url = null
+                                url = null,
+                                previewUrl = null
                             )
                         )
                     }
@@ -481,7 +483,8 @@ class StreamingService : MediaSessionService() {
                     station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
                     title = title,
                     artist = artist,
-                    url = null
+                    url = null,
+                    previewUrl = null
                 )
             )
         }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/MetaLogAdapter.kt
@@ -12,7 +12,8 @@ import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.MetaLogEntry
 
 class MetaLogAdapter(
-    private val onUrlClick: (String) -> Unit
+    private val onUrlClick: (String) -> Unit,
+    private val onPreviewClick: (String) -> Unit
 ) : RecyclerView.Adapter<MetaLogAdapter.ViewHolder>() {
 
     private val items = mutableListOf<MetaLogEntry>()
@@ -26,7 +27,8 @@ class MetaLogAdapter(
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val line1: TextView = view.findViewById(R.id.log_line1)
         val line2: TextView = view.findViewById(R.id.log_line2)
-        val button: ImageButton = view.findViewById(R.id.log_open_button)
+        val previewButton: ImageButton = view.findViewById(R.id.log_preview_button)
+        val openButton: ImageButton = view.findViewById(R.id.log_open_button)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -48,11 +50,18 @@ class MetaLogAdapter(
         } else {
             holder.itemView.setBackgroundColor(Color.TRANSPARENT)
         }
-        if (!item.url.isNullOrBlank()) {
-            holder.button.visibility = View.VISIBLE
-            holder.button.setOnClickListener { onUrlClick(item.url!!) }
+        if (!item.previewUrl.isNullOrBlank()) {
+            holder.previewButton.visibility = View.VISIBLE
+            holder.previewButton.setOnClickListener { onPreviewClick(item.previewUrl!!) }
         } else {
-            holder.button.visibility = View.GONE
+            holder.previewButton.visibility = View.GONE
+        }
+
+        if (!item.url.isNullOrBlank()) {
+            holder.openButton.visibility = View.VISIBLE
+            holder.openButton.setOnClickListener { onUrlClick(item.url!!) }
+        } else {
+            holder.openButton.visibility = View.GONE
         }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
@@ -10,6 +10,7 @@ data class MetaLogEntry(
     val title: String,
     val artist: String,
     val url: String? = null,
+    val previewUrl: String? = null,
     val manual: Boolean = false
 ) {
     fun formattedTime(): String {

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
@@ -21,7 +21,8 @@ object MetaLogHelper {
             val sameMeta = newest.station == entry.station &&
                 newest.title == entry.title &&
                 newest.artist == entry.artist &&
-                newest.url == entry.url
+                newest.url == entry.url &&
+                newest.previewUrl == entry.previewUrl
 
             if (sameMeta && entry.manual && !newest.manual) {
                 list[0] = entry

--- a/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
@@ -1,7 +1,9 @@
 package at.plankt0n.streamplay.ui
 
 import android.content.Intent
-import android.media.MediaPlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.Player
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -27,7 +29,7 @@ class MetaLogFragment : Fragment() {
     private lateinit var manualFilter: CheckBox
     private var showManualOnly = false
     private var allLogs = mutableListOf<MetaLogEntry>()
-    private var previewPlayer: MediaPlayer? = null
+    private var previewPlayer: ExoPlayer? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -100,13 +102,24 @@ class MetaLogFragment : Fragment() {
     }
 
     private fun playPreview(url: String) {
-        previewPlayer?.release()
-        previewPlayer = MediaPlayer().apply {
-            setDataSource(url)
-            setOnPreparedListener { start() }
-            setOnCompletionListener { releasePlayer() }
-            prepareAsync()
+        if (previewPlayer == null) {
+            previewPlayer = ExoPlayer.Builder(requireContext()).build().apply {
+                addListener(object : Player.Listener {
+                    override fun onPlaybackStateChanged(state: Int) {
+                        if (state == Player.STATE_ENDED || state == Player.STATE_IDLE) {
+                            releasePlayer()
+                        }
+                    }
+                })
+            }
+        } else {
+            previewPlayer?.stop()
+            previewPlayer?.clearMediaItems()
         }
+
+        previewPlayer?.setMediaItem(MediaItem.fromUri(url))
+        previewPlayer?.prepare()
+        previewPlayer?.play()
     }
 
     private fun releasePlayer() {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/MetaLogFragment.kt
@@ -1,6 +1,7 @@
 package at.plankt0n.streamplay.ui
 
 import android.content.Intent
+import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -26,6 +27,7 @@ class MetaLogFragment : Fragment() {
     private lateinit var manualFilter: CheckBox
     private var showManualOnly = false
     private var allLogs = mutableListOf<MetaLogEntry>()
+    private var previewPlayer: MediaPlayer? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -42,10 +44,15 @@ class MetaLogFragment : Fragment() {
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 
-        adapter = MetaLogAdapter { url ->
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-            startActivity(intent)
-        }
+        adapter = MetaLogAdapter(
+            onUrlClick = { url ->
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                startActivity(intent)
+            },
+            onPreviewClick = { url ->
+                playPreview(url)
+            }
+        )
         val recycler = view.findViewById<RecyclerView>(R.id.recyclerMetaLog)
         recycler.layoutManager = LinearLayoutManager(requireContext())
         recycler.adapter = adapter
@@ -90,5 +97,25 @@ class MetaLogFragment : Fragment() {
             matchesQuery && manualOk
         }
         adapter.setItems(filtered)
+    }
+
+    private fun playPreview(url: String) {
+        previewPlayer?.release()
+        previewPlayer = MediaPlayer().apply {
+            setDataSource(url)
+            setOnPreparedListener { start() }
+            setOnCompletionListener { releasePlayer() }
+            prepareAsync()
+        }
+    }
+
+    private fun releasePlayer() {
+        previewPlayer?.release()
+        previewPlayer = null
+    }
+
+    override fun onDestroy() {
+        releasePlayer()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -572,6 +572,7 @@ class PlayerFragment : Fragment() {
             title = trackInfo?.trackName ?: "",
             artist = trackInfo?.artistName ?: "",
             url = trackInfo?.spotifyUrl?.takeIf { it.isNotBlank() },
+            previewUrl = trackInfo?.previewUrl,
             manual = true
         )
 
@@ -591,6 +592,7 @@ class PlayerFragment : Fragment() {
             last.title == (trackInfo?.trackName ?: "") &&
             last.artist == (trackInfo?.artistName ?: "") &&
             last.url == (trackInfo?.spotifyUrl?.takeIf { it.isNotBlank() }) &&
+            last.previewUrl == trackInfo?.previewUrl &&
             last.manual
 
         buttonManualLog.isEnabled = !same

--- a/app/src/main/res/layout/item_meta_log.xml
+++ b/app/src/main/res/layout/item_meta_log.xml
@@ -26,6 +26,14 @@
     </LinearLayout>
 
     <ImageButton
+        android:id="@+id/log_preview_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_button_play"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/desc_button_play_pause" />
+
+    <ImageButton
         android:id="@+id/log_open_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- store Spotify preview URLs in `MetaLogEntry`
- include preview URL check in `MetaLogHelper`
- show a preview play button in meta log items
- play previews in `MetaLogFragment`
- log preview URL for auto and manual logs

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be4681148832fb0ac4972ceb1f57f