### PR TITLE
Extend MetaLog with full metadata and logging

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -423,7 +423,8 @@ class StreamingService : MediaSessionService() {
                                 station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
                                 title = extendedInfo.trackName,
                                 artist = extendedInfo.artistName,
-                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() }
+                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() },
+                                extendedInfo = extendedInfo
                             )
                         )
                     } else {

--- a/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/data/MetaLogEntry.kt
@@ -10,7 +10,8 @@ data class MetaLogEntry(
     val title: String,
     val artist: String,
     val url: String? = null,
-    val manual: Boolean = false
+    val manual: Boolean = false,
+    val extendedInfo: ExtendedMetaInfo? = null
 ) {
     fun formattedTime(): String {
         val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MetaLogHelper.kt
@@ -1,6 +1,7 @@
 package at.plankt0n.streamplay.helper
 
 import android.content.Context
+import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import at.plankt0n.streamplay.data.MetaLogEntry
@@ -27,6 +28,7 @@ object MetaLogHelper {
                 list[0] = entry
                 val json = Gson().toJson(list)
                 prefs(context).edit().putString(KEY_LOGS, json).apply()
+                Log.d("MetaLogHelper", "Saved log entry: ${Gson().toJson(entry)}")
                 return
             }
         }
@@ -34,6 +36,7 @@ object MetaLogHelper {
         list.add(0, entry) // newest first
         val json = Gson().toJson(list)
         prefs(context).edit().putString(KEY_LOGS, json).apply()
+        Log.d("MetaLogHelper", "Saved log entry: ${Gson().toJson(entry)}")
     }
 
     fun getLogs(context: Context): MutableList<MetaLogEntry> {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -40,6 +40,7 @@ import at.plankt0n.streamplay.helper.MetaLogHelper
 import at.plankt0n.streamplay.viewmodel.UITrackViewModel
 import at.plankt0n.streamplay.viewmodel.UITrackInfo
 import at.plankt0n.streamplay.data.MetaLogEntry
+import at.plankt0n.streamplay.data.ExtendedMetaInfo
 import at.plankt0n.streamplay.Keys
 import androidx.media3.common.Player
 import com.bumptech.glide.Glide
@@ -566,13 +567,29 @@ class PlayerFragment : Fragment() {
         val station = extras.getString("EXTRA_STATION_NAME") ?: ""
         val trackInfo = spotifyTrackViewModel.trackInfo.value
 
+        val extended = trackInfo?.let {
+            ExtendedMetaInfo(
+                trackName = it.trackName,
+                artistName = it.artistName,
+                albumName = it.albumName,
+                albumReleaseDate = it.albumReleaseDate,
+                spotifyUrl = it.spotifyUrl,
+                bestCoverUrl = it.bestCoverUrl,
+                durationMs = it.durationMs,
+                popularity = it.popularity,
+                previewUrl = it.previewUrl,
+                genre = it.genre
+            )
+        }
+
         val entry = MetaLogEntry(
             timestamp = System.currentTimeMillis(),
             station = station,
             title = trackInfo?.trackName ?: "",
             artist = trackInfo?.artistName ?: "",
             url = trackInfo?.spotifyUrl?.takeIf { it.isNotBlank() },
-            manual = true
+            manual = true,
+            extendedInfo = extended
         )
 
         MetaLogHelper.addLog(requireContext(), entry)


### PR DESCRIPTION
## Summary
- include `ExtendedMetaInfo` in `MetaLogEntry`
- log every saved `MetaLogEntry` to Logcat
- store extended metadata in manual log save
- persist extended metadata when fetched from Spotify

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c02217b0c832f8687e7f4463da15a