### PR TITLE
Add blurred cover background effect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
         implementation("com.google.code.gson:gson:2.10.1")
     //Glide
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
@@ -1,21 +1,14 @@
 // Datei: at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
 package at.plankt0n.streamplay.adapter
 
-import android.animation.ValueAnimator
-import android.graphics.Bitmap
-import android.graphics.Color
-import android.graphics.drawable.GradientDrawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.LiveCoverHelper
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.BitmapImageViewTarget
 import com.google.android.material.imageview.ShapeableImageView
 
 class CoverPageAdapter(
@@ -40,48 +33,18 @@ class CoverPageAdapter(
     override fun onBindViewHolder(holder: CoverViewHolder, position: Int) {
         val item = mediaItems[position]
 
-        Glide.with(holder.itemView)
-            .asBitmap()
-            .load(item.iconURL)
-            .placeholder(R.drawable.ic_placeholder_logo)
-            .error(R.drawable.ic_stationcover_placeholder)
-            .into(object : BitmapImageViewTarget(holder.coverImage) {
-                override fun setResource(resource: Bitmap?) {
-                    super.setResource(resource)
-                    resource?.let { bitmap ->
-                        Palette.from(bitmap).generate { palette ->
-                            palette?.let {
-                                val dominantColor = it.getDominantColor(
-                                    holder.itemView.context.getColor(R.color.default_background)
-                                )
-
-                                // Farbton sanfter machen (leichter entsättigen, Gelb-Töne neutralisieren)
-                                val hsv = FloatArray(3)
-                                Color.colorToHSV(dominantColor, hsv)
-                                hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f) // Sättigung reduzieren
-                                hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f) // Helligkeit leicht erhöhen
-                                val smoothColor = Color.HSVToColor(hsv)
-
-                                // Nur animieren, wenn Farbe oder Effekt sich ändert
-                                if (holder.lastColor != smoothColor || holder.lastEffect != backgroundEffect) {
-                                    val fromColor = holder.lastColor
-                                        ?: holder.itemView.context.getColor(R.color.default_background)
-                                    val animator = ValueAnimator.ofArgb(fromColor, smoothColor)
-                                    animator.duration = 400
-                                    animator.addUpdateListener { a ->
-                                        val color = a.animatedValue as Int
-                                        val gradient = LiveCoverHelper.createGradient(color, backgroundEffect)
-                                        holder.itemView.background = gradient
-                                    }
-                                    animator.start()
-                                    holder.lastColor = smoothColor
-                                    holder.lastEffect = backgroundEffect
-                                }
-                            }
-                        }
-                    }
-                }
-            })
+        LiveCoverHelper.loadCoverWithBackground(
+            context = holder.itemView.context,
+            imageUrl = item.iconURL,
+            imageView = holder.coverImage,
+            backgroundTarget = holder.itemView,
+            defaultColor = holder.itemView.context.getColor(R.color.default_background),
+            lastColor = holder.lastColor,
+            lastEffect = holder.lastEffect,
+            effect = backgroundEffect,
+            onNewColor = { holder.lastColor = it },
+            onNewEffect = { holder.lastEffect = it }
+        )
     }
 
     override fun getItemCount(): Int = mediaItems.size

--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -4,13 +4,18 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.GradientDrawable
 import android.view.View
 import android.widget.ImageView
 import at.plankt0n.streamplay.R
 import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.BitmapImageViewTarget
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import androidx.palette.graphics.Palette
+import jp.wasabeef.glide.transformations.BlurTransformation
 
 object LiveCoverHelper {
 
@@ -21,7 +26,8 @@ object LiveCoverHelper {
         SUNSET,
         FOREST,
         DIAGONAL,
-        SPOTLIGHT
+        SPOTLIGHT,
+        BLUR
     }
 
     fun loadCoverWithBackground(
@@ -45,32 +51,56 @@ object LiveCoverHelper {
                 override fun setResource(resource: Bitmap?) {
                     super.setResource(resource)
                     resource?.let { bitmap ->
-                        Palette.from(bitmap).generate { palette ->
-                            palette?.let {
-                                val dominantColor = it.getDominantColor(defaultColor)
-
-                                val hsv = FloatArray(3)
-                                Color.colorToHSV(dominantColor, hsv)
-                                hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
-                                hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
-                                val smoothColor = Color.HSVToColor(hsv)
-
-                                // Nur animieren, wenn sich Farbe oder Effekt ändert
-                                if (lastColor != smoothColor || lastEffect != effect) {
-                                    val animator = ValueAnimator.ofArgb(
-                                        lastColor ?: defaultColor,
-                                        smoothColor
-                                    ).apply {
-                                        duration = 400
-                                        addUpdateListener { anim ->
-                                            val color = anim.animatedValue as Int
-                                            val gradient = createGradient(color, effect)
-                                            backgroundTarget.background = gradient
-                                        }
+                        if (effect == BackgroundEffect.BLUR) {
+                            Glide.with(context)
+                                .asBitmap()
+                                .load(imageUrl)
+                                .apply(
+                                    RequestOptions()
+                                        .centerCrop()
+                                        .transform(BlurTransformation(25, 3))
+                                )
+                                .into(object : CustomTarget<Bitmap>() {
+                                    override fun onResourceReady(
+                                        resource: Bitmap,
+                                        transition: Transition<in Bitmap>?
+                                    ) {
+                                        backgroundTarget.background =
+                                            BitmapDrawable(context.resources, resource)
+                                        onNewColor(defaultColor)
+                                        onNewEffect(effect)
                                     }
-                                    animator.start()
-                                    onNewColor(smoothColor)
-                                    onNewEffect(effect)
+
+                                    override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
+                                })
+                        } else {
+                            Palette.from(bitmap).generate { palette ->
+                                palette?.let {
+                                    val dominantColor = it.getDominantColor(defaultColor)
+
+                                    val hsv = FloatArray(3)
+                                    Color.colorToHSV(dominantColor, hsv)
+                                    hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
+                                    hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
+                                    val smoothColor = Color.HSVToColor(hsv)
+
+                                    // Nur animieren, wenn sich Farbe oder Effekt ändert
+                                    if (lastColor != smoothColor || lastEffect != effect) {
+                                        val animator = ValueAnimator.ofArgb(
+                                            lastColor ?: defaultColor,
+                                            smoothColor
+                                        ).apply {
+                                            duration = 400
+                                            addUpdateListener { anim ->
+                                                val color = anim.animatedValue as Int
+                                                val gradient = createGradient(color, effect)
+                                                backgroundTarget.background = gradient
+                                            }
+                                        }
+                                        animator.start()
+                                        onNewColor(smoothColor)
+                                        onNewEffect(effect)
+                                    }
                                 }
                             }
                         }
@@ -116,6 +146,7 @@ object LiveCoverHelper {
                 colors = intArrayOf(lighter, color)
                 gradientRadius = 600f
             }
+            BackgroundEffect.BLUR -> GradientDrawable().apply { setColor(color) }
         }.apply { cornerRadius = 0f }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -87,7 +87,8 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
             getString(R.string.bg_effect_sunset),
             getString(R.string.bg_effect_forest),
             getString(R.string.bg_effect_diagonal),
-            getString(R.string.bg_effect_spotlight)
+            getString(R.string.bg_effect_spotlight),
+            getString(R.string.bg_effect_blur)
         )
         entryValues = arrayOf(
             LiveCoverHelper.BackgroundEffect.FADE.name,
@@ -96,7 +97,8 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
             LiveCoverHelper.BackgroundEffect.SUNSET.name,
             LiveCoverHelper.BackgroundEffect.FOREST.name,
             LiveCoverHelper.BackgroundEffect.DIAGONAL.name,
-            LiveCoverHelper.BackgroundEffect.SPOTLIGHT.name
+            LiveCoverHelper.BackgroundEffect.SPOTLIGHT.name,
+            LiveCoverHelper.BackgroundEffect.BLUR.name
         )
         setDefaultValue(LiveCoverHelper.BackgroundEffect.FADE.name)
         category = SettingsCategory.UI

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="bg_effect_forest">Forest</string>
     <string name="bg_effect_diagonal">Diagonal</string>
     <string name="bg_effect_spotlight">Spotlight</string>
+    <string name="bg_effect_blur">Blur</string>
     <string name="settings_cover_mode">Cover Source</string>
     <string name="cover_mode_station">Station Cover</string>
     <string name="cover_mode_meta">Metadata Cover</string>


### PR DESCRIPTION
## Summary
- add new `BLUR` background effect using a heavily blurred cover image that fills the screen
- allow users to select the blur effect in settings and centralize cover loading logic
- include glide-transformations dependency for blur support

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689712744bec832f9037472242b28536