### PR TITLE
feat: add configurable Spotify meta settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,9 @@ dependencies {
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
+    // Text recognition for scanning keys
+    implementation("com.google.mlkit:text-recognition:16.0.0")
+
 
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -16,8 +16,9 @@ object Keys {
 
 
     //Spotify
-    const val KEY_SPOTIFY_CLIENT_ID = "cc55a94b922c496a84c4a725242a313b"
-    const val KEY_SPOTIFY_CLIENT_SECRET = "1893b26ecec74a4984152f0d86200b63"
+    const val PREF_USE_SPOTIFY_META = "use_spotify_meta"
+    const val PREF_SPOTIFY_CLIENT_ID = "spotify_client_id"
+    const val PREF_SPOTIFY_CLIENT_SECRET = "spotify_client_secret"
 
     const val KEY_META_LOGS_PREFS = "meta_log_prefs"
     const val KEY_META_LOGS = "metadata_logs"

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -402,81 +402,113 @@ class StreamingService : MediaSessionService() {
         }
 
         if (artist.isNotEmpty() && title.isNotEmpty()) {
-            GlobalScope.launch(Dispatchers.IO) {
-                val extendedInfo =
-                    SpotifyMetaReader.getExtendedMetaInfo(this@StreamingService, artist, title)
-                withContext(Dispatchers.Main) {
-                    if (stationUuidAtFetchStart != currentStationUuid) {
-                        Log.d("StreamingService", "ℹ️ Station changed during metadata fetch, ignoring results")
-                        updateMediaItemMetadata("", "", fallbackartworkUri ?: "")
-                        return@withContext
-                    }
-                    if (extendedInfo != null) {
-                        Log.d(
-                            "SpotifyMetaReader",
-                            "✅ Spotify-Infos gefunden: ${extendedInfo.trackName}"
-                        )
+            val prefs = getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+            val useSpotify = prefs.getBoolean(Keys.PREF_USE_SPOTIFY_META, false)
+            val hasKeys = !prefs.getString(Keys.PREF_SPOTIFY_CLIENT_ID, "").isNullOrBlank() &&
+                    !prefs.getString(Keys.PREF_SPOTIFY_CLIENT_SECRET, "").isNullOrBlank()
 
-
-                        UITrackRepository.updateTrackInfo(
-                            UITrackInfo(
-                                trackName = extendedInfo.trackName,
-                                artistName = extendedInfo.artistName,
-                                bestCoverUrl = extendedInfo.bestCoverUrl,
-                                albumName = extendedInfo.albumName,
-                                durationMs = extendedInfo.durationMs,
-                                albumReleaseDate = extendedInfo.albumReleaseDate,
-                                popularity = extendedInfo.popularity,
-                                spotifyUrl = extendedInfo.spotifyUrl,
-                                previewUrl = extendedInfo.previewUrl,
-                                genre = extendedInfo.genre
+            if (useSpotify && hasKeys) {
+                GlobalScope.launch(Dispatchers.IO) {
+                    val extendedInfo =
+                        SpotifyMetaReader.getExtendedMetaInfo(this@StreamingService, artist, title)
+                    withContext(Dispatchers.Main) {
+                        if (stationUuidAtFetchStart != currentStationUuid) {
+                            Log.d("StreamingService", "ℹ️ Station changed during metadata fetch, ignoring results")
+                            updateMediaItemMetadata("", "", fallbackartworkUri ?: "")
+                            return@withContext
+                        }
+                        if (extendedInfo != null) {
+                            Log.d(
+                                "SpotifyMetaReader",
+                                "✅ Spotify-Infos gefunden: ${extendedInfo.trackName}"
                             )
-                        )
 
+                            UITrackRepository.updateTrackInfo(
+                                UITrackInfo(
+                                    trackName = extendedInfo.trackName,
+                                    artistName = extendedInfo.artistName,
+                                    bestCoverUrl = extendedInfo.bestCoverUrl,
+                                    albumName = extendedInfo.albumName,
+                                    durationMs = extendedInfo.durationMs,
+                                    albumReleaseDate = extendedInfo.albumReleaseDate,
+                                    popularity = extendedInfo.popularity,
+                                    spotifyUrl = extendedInfo.spotifyUrl,
+                                    previewUrl = extendedInfo.previewUrl,
+                                    genre = extendedInfo.genre
+                                )
+                            )
 
-                        updateMediaItemMetadata(
-                            title = extendedInfo.trackName,
-                            artist = extendedInfo.artistName,
-                            artworkUri = extendedInfo.bestCoverUrl ?: ""
-                        )
-
-                        MetaLogHelper.addLog(
-                            this@StreamingService,
-                            MetaLogEntry(
-                                timestamp = System.currentTimeMillis(),
-                                station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                            updateMediaItemMetadata(
                                 title = extendedInfo.trackName,
                                 artist = extendedInfo.artistName,
-                                url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() }
+                                artworkUri = extendedInfo.bestCoverUrl ?: ""
                             )
-                        )
-                    } else {
-                        Log.w(
-                            "SpotifyMetaReader",
-                            "❌ Keine Spotify-Daten gefunden für: $artist - $title"
-                        )
-                        updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
-                        UITrackRepository.updateTrackInfo(
-                            UITrackInfo(
-                                trackName = title,
-                                artistName = artist,
-                                bestCoverUrl = fallbackartworkUri,
-                                previewUrl = null,
-                                genre = ""
+
+                            MetaLogHelper.addLog(
+                                this@StreamingService,
+                                MetaLogEntry(
+                                    timestamp = System.currentTimeMillis(),
+                                    station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                                    title = extendedInfo.trackName,
+                                    artist = extendedInfo.artistName,
+                                    url = extendedInfo.spotifyUrl.takeIf { it.isNotBlank() }
+                                )
                             )
-                        )
-                        MetaLogHelper.addLog(
-                            this@StreamingService,
-                            MetaLogEntry(
-                                timestamp = System.currentTimeMillis(),
-                                station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
-                                title = title,
-                                artist = artist,
-                                url = null
+                        } else {
+                            Log.w(
+                                "SpotifyMetaReader",
+                                "❌ Keine Spotify-Daten gefunden für: $artist - $title"
                             )
-                        )
+                            updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
+                            UITrackRepository.updateTrackInfo(
+                                UITrackInfo(
+                                    trackName = title,
+                                    artistName = artist,
+                                    bestCoverUrl = fallbackartworkUri,
+                                    previewUrl = null,
+                                    genre = ""
+                                )
+                            )
+                            MetaLogHelper.addLog(
+                                this@StreamingService,
+                                MetaLogEntry(
+                                    timestamp = System.currentTimeMillis(),
+                                    station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                                    title = title,
+                                    artist = artist,
+                                    url = null
+                                )
+                            )
+                        }
                     }
                 }
+            } else {
+                GlobalScope.launch(Dispatchers.Main) {
+                    if (stationUuidAtFetchStart != currentStationUuid) {
+                        updateMediaItemMetadata("", "", fallbackartworkUri ?: "")
+                        return@launch
+                    }
+                    updateMediaItemMetadata(title, artist, fallbackartworkUri ?: "")
+                }
+                UITrackRepository.updateTrackInfo(
+                    UITrackInfo(
+                        trackName = title,
+                        artistName = artist,
+                        bestCoverUrl = fallbackartworkUri,
+                        previewUrl = null,
+                        genre = ""
+                    )
+                )
+                MetaLogHelper.addLog(
+                    this@StreamingService,
+                    MetaLogEntry(
+                        timestamp = System.currentTimeMillis(),
+                        station = player.currentMediaItem?.mediaMetadata?.extras?.getString("EXTRA_STATION_NAME") ?: "",
+                        title = title,
+                        artist = artist,
+                        url = null
+                    )
+                )
             }
         } else {
             Log.d(

--- a/app/src/main/java/at/plankt0n/streamplay/helper/SpotifyMetaReader.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/SpotifyMetaReader.kt
@@ -19,8 +19,10 @@ object SpotifyMetaReader {
     private var tokenExpirationTime: Long = 0 // Millisekunden
 
     private suspend fun getAccessToken(context: Context): String = withContext(Dispatchers.IO) {
-        val clientId = Keys.KEY_SPOTIFY_CLIENT_ID
-        val clientSecret = Keys.KEY_SPOTIFY_CLIENT_SECRET
+        val prefs = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        val clientId = prefs.getString(Keys.PREF_SPOTIFY_CLIENT_ID, "") ?: ""
+        val clientSecret = prefs.getString(Keys.PREF_SPOTIFY_CLIENT_SECRET, "") ?: ""
+        if (clientId.isBlank() || clientSecret.isBlank()) throw IOException("Spotify credentials missing")
         val credentials = "$clientId:$clientSecret"
         val encodedCredentials = Base64.encodeToString(credentials.toByteArray(), Base64.NO_WRAP)
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/ScanEditTextPreference.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/ScanEditTextPreference.kt
@@ -1,0 +1,28 @@
+package at.plankt0n.streamplay.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.Button
+import androidx.preference.EditTextPreference
+import at.plankt0n.streamplay.R
+
+class ScanEditTextPreference @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.preference.R.attr.editTextPreferenceStyle
+) : EditTextPreference(context, attrs, defStyleAttr) {
+
+    var onScanRequest: (() -> Unit)? = null
+
+    init {
+        dialogLayoutResource = R.layout.preference_scan_edittext
+    }
+
+    override fun onBindDialogView(view: View) {
+        super.onBindDialogView(view)
+        view.findViewById<Button>(R.id.scan_button)?.setOnClickListener {
+            onScanRequest?.invoke()
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -18,9 +18,12 @@ import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 
 /** Possible categories a preference can belong to. */
-enum class SettingsCategory { PLAYBACK, UI, METAINFO, PERSONAL_SYNC, ABOUT }
+enum class SettingsCategory { PLAYBACK, UI, METAINFO, SPOTIFY_META, PERSONAL_SYNC, ABOUT }
 
 private const val EXTRA_CATEGORY = "category"
 
@@ -55,6 +58,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 SettingsCategory.PLAYBACK -> getString(R.string.settings_category_playback)
                 SettingsCategory.UI -> getString(R.string.settings_category_ui)
                 SettingsCategory.METAINFO -> getString(R.string.settings_category_metainfo)
+                SettingsCategory.SPOTIFY_META -> getString(R.string.settings_category_spotify_meta)
                 SettingsCategory.PERSONAL_SYNC -> getString(R.string.settings_category_personal_sync)
                 SettingsCategory.ABOUT -> getString(R.string.settings_category_about)
             }
@@ -62,6 +66,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 SettingsCategory.PLAYBACK -> context.getDrawable(R.drawable.ic_button_play)
                 SettingsCategory.UI -> context.getDrawable(R.drawable.ic_sheet_settings)
                 SettingsCategory.METAINFO -> context.getDrawable(R.drawable.ic_sheet_discover)
+                SettingsCategory.SPOTIFY_META -> context.getDrawable(R.drawable.ic_sheet_settings)
                 SettingsCategory.PERSONAL_SYNC -> context.getDrawable(R.drawable.ic_sheet_settings)
                 SettingsCategory.ABOUT -> context.getDrawable(R.mipmap.ic_launcher)
             }
@@ -145,6 +150,109 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
+
+    val spotifyApiKeyPref = ScanEditTextPreference(context).apply {
+        key = Keys.PREF_SPOTIFY_CLIENT_ID
+        title = getString(R.string.settings_spotify_api_key)
+        setDefaultValue("")
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                value
+            }
+        }
+        category = SettingsCategory.SPOTIFY_META
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val spotifySecretKeyPref = ScanEditTextPreference(context).apply {
+        key = Keys.PREF_SPOTIFY_CLIENT_SECRET
+        title = getString(R.string.settings_spotify_secret_key)
+        setDefaultValue("")
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                value
+            }
+        }
+        category = SettingsCategory.SPOTIFY_META
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val useSpotifyMetaPref = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_USE_SPOTIFY_META
+        title = getString(R.string.settings_use_spotify_meta)
+        setDefaultValue(false)
+        isEnabled = false
+        category = SettingsCategory.SPOTIFY_META
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    fun updateSpotifyToggle(api: String? = spotifyApiKeyPref.text, secret: String? = spotifySecretKeyPref.text) {
+        val hasKeys = !api.isNullOrBlank() && !secret.isNullOrBlank()
+        useSpotifyMetaPref.isEnabled = hasKeys
+        if (!hasKeys) {
+            useSpotifyMetaPref.isChecked = false
+        }
+    }
+
+    val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
+    val spotifyApiScanLauncher = registerForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
+        bitmap?.let {
+            val image = InputImage.fromBitmap(it, 0)
+            textRecognizer.process(image)
+                .addOnSuccessListener { visionText ->
+                    val resultText = visionText.text.replace("\\s".toRegex(), "")
+                    spotifyApiKeyPref.text = resultText
+                    updateSpotifyToggle(resultText, spotifySecretKeyPref.text)
+                }
+                .addOnFailureListener {
+                    Toast.makeText(context, R.string.scan_failed, Toast.LENGTH_SHORT).show()
+                }
+        }
+    }
+
+    spotifyApiKeyPref.onScanRequest = {
+        spotifyApiScanLauncher.launch(null)
+    }
+
+    val spotifySecretScanLauncher = registerForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
+        bitmap?.let {
+            val image = InputImage.fromBitmap(it, 0)
+            textRecognizer.process(image)
+                .addOnSuccessListener { visionText ->
+                    val resultText = visionText.text.replace("\\s".toRegex(), "")
+                    spotifySecretKeyPref.text = resultText
+                    updateSpotifyToggle(spotifyApiKeyPref.text, resultText)
+                }
+                .addOnFailureListener {
+                    Toast.makeText(context, R.string.scan_failed, Toast.LENGTH_SHORT).show()
+                }
+        }
+    }
+
+    spotifySecretKeyPref.onScanRequest = {
+        spotifySecretScanLauncher.launch(null)
+    }
+
+    spotifyApiKeyPref.setOnPreferenceChangeListener { _, newValue ->
+        val newText = newValue as String
+        updateSpotifyToggle(newText, spotifySecretKeyPref.text)
+        true
+    }
+
+    spotifySecretKeyPref.setOnPreferenceChangeListener { _, newValue ->
+        val newText = newValue as String
+        updateSpotifyToggle(spotifyApiKeyPref.text, newText)
+        true
+    }
+
+    updateSpotifyToggle()
 
     val personalUrlPref = EditTextPreference(context).apply {
         key = "personal_sync_url"
@@ -271,6 +379,9 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         bannerSwitch,
         backgroundEffectPref,
         coverModePref,
+        spotifyApiKeyPref,
+        spotifySecretKeyPref,
+        useSpotifyMetaPref,
         personalUrlPref,
         personalSyncPref,
         personalExportPref,

--- a/app/src/main/res/layout/preference_scan_edittext.xml
+++ b/app/src/main/res/layout/preference_scan_edittext.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <EditText
+        android:id="@android:id/edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/scan_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_scan_code"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="settings_category_playback">Playback</string>
     <string name="settings_category_ui">UI Settings</string>
     <string name="settings_category_metainfo">Metainfo Settings</string>
+    <string name="settings_category_spotify_meta">Spotify Meta</string>
     <string name="settings_category_personal_sync">Personal Sync</string>
     <string name="settings_category_about">About</string>
     <string name="settings_app_version">App Version</string>
@@ -147,4 +148,9 @@
     <string name="settings_cover_mode">Cover Source</string>
     <string name="cover_mode_station">Station Cover</string>
     <string name="cover_mode_meta">Metadata Cover</string>
+    <string name="settings_use_spotify_meta">Use Spotify Meta</string>
+    <string name="settings_spotify_api_key">Spotify API Key</string>
+    <string name="settings_spotify_secret_key">Spotify Secret Key</string>
+    <string name="settings_scan_code">Scan</string>
+    <string name="scan_failed">Scan failed</string>
 </resources>


### PR DESCRIPTION
## Summary
- remove built-in Spotify credentials
- add Spotify Meta settings for API key, secret, and enable toggle
- use user-provided keys and toggle before fetching Spotify metadata
- allow scanning Spotify keys via camera text recognition

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985d05c494832faf2f529c78eccd6d