### PR TITLE
Add volume slider popup on mute button long press

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -21,6 +21,8 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.ViewFlipper
+import android.widget.PopupWindow
+import android.widget.SeekBar
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -343,6 +345,7 @@ class PlayerFragment : Fragment() {
             }
             isMuted = !isMuted
         }
+        buttonMute.setOnLongClickListener { showVolumePopup(it); true }
         updateManualLogButtonState(spotifyTrackViewModel.trackInfo.value)
         initialized = true
     }
@@ -506,6 +509,43 @@ class PlayerFragment : Fragment() {
     private fun updatePlayPauseIcon(isPlaying: Boolean) {
         val iconRes = if (isPlaying) R.drawable.ic_button_pause else R.drawable.ic_button_play
         playPauseButton.setImageResource(iconRes)
+    }
+
+    private fun showVolumePopup(anchor: View) {
+        val popupView = LayoutInflater.from(requireContext()).inflate(R.layout.volume_slider_popup, null)
+        val seekBar = popupView.findViewById<SeekBar>(R.id.volume_seekbar)
+        val audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+        seekBar.max = maxVolume
+        val currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+        seekBar.progress = currentVolume
+
+        val popup = PopupWindow(popupView, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, true)
+        popup.isOutsideTouchable = true
+
+        popupView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+        val popupHeight = popupView.measuredHeight
+        popup.showAsDropDown(anchor, 0, -anchor.height - popupHeight)
+
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (!fromUser) return
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, progress, 0)
+                if (progress == 0) {
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
+                    isMuted = true
+                    buttonMute.setImageResource(R.drawable.ic_button_muted)
+                } else {
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
+                    isMuted = false
+                    buttonMute.setImageResource(R.drawable.ic_button_unmuted)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) { }
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) { }
+        })
     }
 
     private fun reloadPlaylist() {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -21,8 +21,8 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.ViewFlipper
-import android.widget.PopupWindow
 import android.widget.SeekBar
+import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -67,6 +67,7 @@ class PlayerFragment : Fragment() {
     private lateinit var updateBadge: TextView
     private lateinit var buttonSpotify: ImageButton
     private lateinit var buttonMute: ImageButton
+    private var volumeSlider: SeekBar? = null
     private lateinit var buttonShare: ImageButton
     private lateinit var buttonManualLog: ImageButton
     private lateinit var shortcutRecyclerView: RecyclerView
@@ -511,21 +512,25 @@ class PlayerFragment : Fragment() {
         playPauseButton.setImageResource(iconRes)
     }
 
-    private fun showVolumePopup(anchor: View) {
-        val popupView = LayoutInflater.from(requireContext()).inflate(R.layout.volume_slider_popup, null)
-        val seekBar = popupView.findViewById<SeekBar>(R.id.volume_seekbar)
+    private fun showVolumePopup(@Suppress("UNUSED_PARAMETER") anchor: View) {
+        if (volumeSlider != null) return
+        val rootView = view ?: return
+        val overlayContainer = rootView.findViewById<FrameLayout>(R.id.station_overlay_container)
+        val previousContent = overlayContainer.getChildAt(0)
+        previousContent?.visibility = View.GONE
+
+        val seekBar = LayoutInflater.from(requireContext()).inflate(
+            R.layout.volume_slider_popup, overlayContainer, false
+        ) as SeekBar
+        volumeSlider = seekBar
+
         val audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
         val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
         seekBar.max = maxVolume
         val currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         seekBar.progress = currentVolume
 
-        val popup = PopupWindow(popupView, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, true)
-        popup.isOutsideTouchable = true
-
-        popupView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        val popupHeight = popupView.measuredHeight
-        popup.showAsDropDown(anchor, 0, -anchor.height - popupHeight)
+        overlayContainer.addView(seekBar)
 
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
@@ -544,7 +549,11 @@ class PlayerFragment : Fragment() {
 
             override fun onStartTrackingTouch(seekBar: SeekBar?) { }
 
-            override fun onStopTrackingTouch(seekBar: SeekBar?) { }
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                overlayContainer.removeView(seekBar)
+                previousContent?.visibility = View.VISIBLE
+                volumeSlider = null
+            }
         })
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -532,9 +532,19 @@ class PlayerFragment : Fragment() {
 
         overlayContainer.addView(seekBar)
 
+        val handler = Handler(Looper.getMainLooper())
+        val dismissRunnable = Runnable {
+            overlayContainer.removeView(seekBar)
+            previousContent?.visibility = View.VISIBLE
+            volumeSlider = null
+        }
+        handler.postDelayed(dismissRunnable, 5000)
+
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 if (!fromUser) return
+                handler.removeCallbacks(dismissRunnable)
+                handler.postDelayed(dismissRunnable, 5000)
                 audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, progress, 0)
                 if (progress == 0) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
@@ -547,12 +557,13 @@ class PlayerFragment : Fragment() {
                 }
             }
 
-            override fun onStartTrackingTouch(seekBar: SeekBar?) { }
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {
+                handler.removeCallbacks(dismissRunnable)
+            }
 
             override fun onStopTrackingTouch(seekBar: SeekBar?) {
-                overlayContainer.removeView(seekBar)
-                previousContent?.visibility = View.VISIBLE
-                volumeSlider = null
+                handler.removeCallbacks(dismissRunnable)
+                dismissRunnable.run()
             }
         })
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -517,7 +517,7 @@ class PlayerFragment : Fragment() {
         val rootView = view ?: return
         val overlayContainer = rootView.findViewById<FrameLayout>(R.id.station_overlay_container)
         val previousContent = overlayContainer.getChildAt(0)
-        previousContent?.visibility = View.GONE
+        previousContent?.visibility = View.INVISIBLE
 
         val seekBar = LayoutInflater.from(requireContext()).inflate(
             R.layout.volume_slider_popup, overlayContainer, false

--- a/app/src/main/res/drawable/volume_slider_thumb.xml
+++ b/app/src/main/res/drawable/volume_slider_thumb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-    <size android:width="32dp" android:height="32dp" />
-    <solid android:color="@android:color/white" />
-    <stroke android:width="2dp" android:color="@android:color/darker_gray" />
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <size android:width="12dp" android:height="32dp" />
+    <corners android:radius="6dp" />
+    <solid android:color="@android:color/black" />
 </shape>

--- a/app/src/main/res/drawable/volume_slider_thumb.xml
+++ b/app/src/main/res/drawable/volume_slider_thumb.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <size android:width="32dp" android:height="32dp" />
+    <solid android:color="@android:color/white" />
+    <stroke android:width="2dp" android:color="@android:color/darker_gray" />
+</shape>

--- a/app/src/main/res/layout/volume_slider_popup.xml
+++ b/app/src/main/res/layout/volume_slider_popup.xml
@@ -3,4 +3,6 @@
     android:id="@+id/volume_seekbar"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:contentDescription="@string/desc_volume_slider" />
+    android:contentDescription="@string/desc_volume_slider"
+    android:thumb="@drawable/volume_slider_thumb"
+    android:thumbOffset="16dp" />

--- a/app/src/main/res/layout/volume_slider_popup.xml
+++ b/app/src/main/res/layout/volume_slider_popup.xml
@@ -3,6 +3,8 @@
     android:id="@+id/volume_seekbar"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginStart="5mm"
+    android:layout_marginEnd="5mm"
     android:contentDescription="@string/desc_volume_slider"
     android:thumb="@drawable/volume_slider_thumb"
     android:thumbOffset="16dp" />

--- a/app/src/main/res/layout/volume_slider_popup.xml
+++ b/app/src/main/res/layout/volume_slider_popup.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:background="@android:drawable/dialog_holo_light_frame">
+
+    <TextView
+        android:id="@+id/volume_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/desc_volume_slider"/>
+
+    <SeekBar
+        android:id="@+id/volume_seekbar"
+        android:layout_width="wrap_content"
+        android:layout_height="150dp"
+        android:rotation="270"
+        android:contentDescription="@string/desc_volume_slider"
+        android:layout_gravity="center_horizontal"/>
+</LinearLayout>

--- a/app/src/main/res/layout/volume_slider_popup.xml
+++ b/app/src/main/res/layout/volume_slider_popup.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="8dp"
-    android:background="@android:drawable/dialog_holo_light_frame">
-
-    <TextView
-        android:id="@+id/volume_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/desc_volume_slider"/>
-
-    <SeekBar
-        android:id="@+id/volume_seekbar"
-        android:layout_width="wrap_content"
-        android:layout_height="150dp"
-        android:rotation="270"
-        android:contentDescription="@string/desc_volume_slider"
-        android:layout_gravity="center_horizontal"/>
-</LinearLayout>
+<SeekBar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/volume_seekbar"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:contentDescription="@string/desc_volume_slider" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="desc_button_share">Share button</string>
     <string name="desc_button_menu">Menu button</string>
 
+    <string name="desc_volume_slider">Volume slider</string>
+
     <string name="desc_metainfo_overlay_container">Metainfo overlay container</string>
     <string name="desc_metainfo_overlay_image">Meta image</string>
     <string name="desc_metainfo_overlay_texts_container">Container for overlay texts</string>


### PR DESCRIPTION
## Summary
- add vertical volume slider popup layout and accessibility string
- open volume slider via mute button long-press
- allow adjusting stream volume and update mute icon accordingly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689867af2d64832fa99103b625be8462