### PR TITLE
feat(settings): add camera text scanning option

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,16 @@ dependencies {
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
+    // ML Kit text recognition for camera scanning
+    implementation("com.google.mlkit:text-recognition:16.0.0")
+
+    // CameraX for live text scanning
+    val cameraXVersion = "1.3.3"
+    implementation("androidx.camera:camera-core:$cameraXVersion")
+    implementation("androidx.camera:camera-camera2:$cameraXVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraXVersion")
+    implementation("androidx.camera:camera-view:$cameraXVersion")
+
 
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
@@ -35,6 +36,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.LiveScanActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
 
         <service
             android:name=".StreamingService"

--- a/app/src/main/java/at/plankt0n/streamplay/ui/LiveScanActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/LiveScanActivity.kt
@@ -1,0 +1,136 @@
+package at.plankt0n.streamplay.ui
+
+import android.content.Intent
+import android.graphics.Rect
+import android.os.Bundle
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import at.plankt0n.streamplay.R
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class LiveScanActivity : AppCompatActivity() {
+    private lateinit var previewView: PreviewView
+    private lateinit var root: FrameLayout
+    private lateinit var resultView: TextView
+    private lateinit var cameraExecutor: ExecutorService
+    private val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private var currentText: String = ""
+    private var pendingText: String? = null
+    private var stableCount = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_live_scan)
+
+        previewView = findViewById(R.id.previewView)
+        root = findViewById(R.id.root)
+        resultView = findViewById(R.id.recognizedText)
+
+        cameraExecutor = Executors.newSingleThreadExecutor()
+        startCamera()
+
+        root.setOnClickListener {
+            val text = currentText.trim()
+            if (text.isNotEmpty()) {
+                val data = Intent().putExtra("scanned_text", text)
+                setResult(RESULT_OK, data)
+                finish()
+            }
+        }
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build().also {
+                    it.setAnalyzer(cameraExecutor) { imageProxy ->
+                        processImage(imageProxy)
+                    }
+                }
+
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, preview, analysis)
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun processImage(imageProxy: ImageProxy) {
+        val mediaImage = imageProxy.image
+        if (mediaImage != null) {
+            val rotation = imageProxy.imageInfo.rotationDegrees
+            val width: Int
+            val height: Int
+            if (rotation == 0 || rotation == 180) {
+                width = mediaImage.width
+                height = mediaImage.height
+            } else {
+                width = mediaImage.height
+                height = mediaImage.width
+            }
+            val cropHeight = height / 24
+            val top = height / 2 - cropHeight / 2
+            val allowedRect = Rect(0, top, width, top + cropHeight)
+            val image = InputImage.fromMediaImage(
+                mediaImage,
+                rotation
+            )
+            textRecognizer.process(image)
+                .addOnSuccessListener { text ->
+                    var bestLine: String? = null
+                    for (block in text.textBlocks) {
+                        for (line in block.lines) {
+                            val box = line.boundingBox
+                            if (box != null && Rect.intersects(allowedRect, box)) {
+                                if (bestLine == null || line.text.length > bestLine!!.length) {
+                                    bestLine = line.text
+                                }
+                            }
+                        }
+                    }
+                    val result = bestLine?.trim() ?: ""
+                    if (result.isNotEmpty()) {
+                        if (result == pendingText) {
+                            stableCount++
+                        } else {
+                            pendingText = result
+                            stableCount = 1
+                        }
+                        if (stableCount >= 3 && result != currentText) {
+                            currentText = result
+                            runOnUiThread { resultView.text = result }
+                        }
+                    } else {
+                        pendingText = null
+                        stableCount = 0
+                    }
+                }
+                .addOnCompleteListener { imageProxy.close() }
+        } else {
+            imageProxy.close()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cameraExecutor.shutdown()
+        textRecognizer.close()
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/OneLineOverlay.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/OneLineOverlay.kt
@@ -1,0 +1,37 @@
+package at.plankt0n.streamplay.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.BlurMaskFilter
+import android.util.AttributeSet
+import android.view.View
+
+class OneLineOverlay @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+    private val backgroundPaint = Paint().apply {
+        color = 0x80000000.toInt()
+        maskFilter = BlurMaskFilter(50f, BlurMaskFilter.Blur.NORMAL)
+    }
+    private val clearPaint = Paint().apply {
+        xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+    }
+
+    init {
+        setLayerType(LAYER_TYPE_SOFTWARE, null)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val save = canvas.saveLayer(0f, 0f, width.toFloat(), height.toFloat(), null)
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), backgroundPaint)
+        val lineHeight = height / 24f
+        val top = height / 2f - lineHeight / 2f
+        canvas.drawRect(0f, top, width.toFloat(), top + lineHeight, clearPaint)
+        canvas.restoreToCount(save)
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -31,6 +31,18 @@ var Preference.category: SettingsCategory?
         extras.putString(EXTRA_CATEGORY, value?.name)
     }
 
+fun PreferenceFragmentCompat.updateSpotifyToggle(
+    api: String? = findPreference<EditTextPreference>(Keys.PREF_SPOTIFY_CLIENT_ID)?.text,
+    secret: String? = findPreference<EditTextPreference>(Keys.PREF_SPOTIFY_CLIENT_SECRET)?.text
+) {
+    val toggle = findPreference<SwitchPreferenceCompat>(Keys.PREF_USE_SPOTIFY_META)
+    val hasKeys = !api.isNullOrBlank() && !secret.isNullOrBlank()
+    toggle?.isEnabled = hasKeys
+    if (!hasKeys) {
+        toggle?.isChecked = false
+    }
+}
+
 fun PreferenceFragmentCompat.initSettingsScreen() {
     val context = preferenceManager.context
     val screen = preferenceManager.createPreferenceScreen(context)
@@ -189,23 +201,13 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
-    fun updateSpotifyToggle(api: String? = spotifyApiKeyPref.text, secret: String? = spotifySecretKeyPref.text) {
-        val hasKeys = !api.isNullOrBlank() && !secret.isNullOrBlank()
-        useSpotifyMetaPref.isEnabled = hasKeys
-        if (!hasKeys) {
-            useSpotifyMetaPref.isChecked = false
-        }
-    }
-
     spotifyApiKeyPref.setOnPreferenceChangeListener { _, newValue ->
-        val newText = newValue as String
-        updateSpotifyToggle(newText, spotifySecretKeyPref.text)
+        updateSpotifyToggle(api = newValue as String)
         true
     }
 
     spotifySecretKeyPref.setOnPreferenceChangeListener { _, newValue ->
-        val newText = newValue as String
-        updateSpotifyToggle(spotifyApiKeyPref.text, newText)
+        updateSpotifyToggle(secret = newValue as String)
         true
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/SettingsFragment.kt
@@ -1,16 +1,26 @@
 package at.plankt0n.streamplay.ui
 
+import android.Manifest
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.os.Bundle
-import androidx.lifecycle.lifecycleScope
-import androidx.preference.Preference
-import androidx.preference.PreferenceFragmentCompat
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.EditTextPreference
+import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
-import android.content.SharedPreferences
 import kotlinx.coroutines.launch
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -30,6 +40,44 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     )
                 }
             } else null
+        }
+    }
+
+    private var scanTarget: EditTextPreference? = null
+    private var scanDialog: ScanEditTextPreferenceDialogFragment? = null
+
+    private val scanLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val target = scanTarget
+            if (result.resultCode == android.app.Activity.RESULT_OK && target != null) {
+                val text = result.data?.getStringExtra("scanned_text")?.trim()
+                if (!text.isNullOrBlank()) {
+                    target.text = text
+                    scanDialog?.setText(text)
+                    updateSpotifyToggle()
+                } else {
+                    Toast.makeText(requireContext(), R.string.scan_no_text, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) {
+                scanLauncher.launch(Intent(requireContext(), LiveScanActivity::class.java))
+            } else {
+                Toast.makeText(requireContext(), R.string.scan_permission_denied, Toast.LENGTH_SHORT).show()
+            }
+        }
+
+    fun startScan(target: EditTextPreference) {
+        scanTarget = target
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            scanLauncher.launch(Intent(requireContext(), LiveScanActivity::class.java))
+        } else {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
         }
     }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -55,6 +103,54 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     }
                 }
                 true
+            }
+        }
+    }
+
+    override fun onDisplayPreferenceDialog(preference: Preference) {
+        if (preference is EditTextPreference &&
+            (preference.key == Keys.PREF_SPOTIFY_CLIENT_ID ||
+                    preference.key == Keys.PREF_SPOTIFY_CLIENT_SECRET ||
+                    preference.key == "personal_sync_url")
+        ) {
+            val dialogFragment = ScanEditTextPreferenceDialogFragment.newInstance(preference.key)
+            scanDialog = dialogFragment
+            dialogFragment.setTargetFragment(this, 0)
+            dialogFragment.show(parentFragmentManager, "androidx.preference.PreferenceFragment.DIALOG")
+        } else {
+            super.onDisplayPreferenceDialog(preference)
+        }
+    }
+
+    class ScanEditTextPreferenceDialogFragment : EditTextPreferenceDialogFragmentCompat() {
+        override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
+            super.onPrepareDialogBuilder(builder)
+            builder.setNeutralButton(R.string.scan, null)
+        }
+
+        override fun onStart() {
+            super.onStart()
+            val parent = targetFragment as? SettingsFragment
+            (dialog as AlertDialog).getButton(DialogInterface.BUTTON_NEUTRAL)
+                .setOnClickListener {
+                    val pref = preference as? EditTextPreference
+                    if (pref != null) {
+                        parent?.startScan(pref)
+                    }
+                }
+        }
+
+        fun setText(value: String) {
+            dialog?.findViewById<android.widget.EditText>(android.R.id.edit)?.setText(value)
+        }
+
+        companion object {
+            fun newInstance(key: String): ScanEditTextPreferenceDialogFragment {
+                val fragment = ScanEditTextPreferenceDialogFragment()
+                val bundle = Bundle(1)
+                bundle.putString(ARG_KEY, key)
+                fragment.arguments = bundle
+                return fragment
             }
         }
     }

--- a/app/src/main/res/layout/activity_live_scan.xml
+++ b/app/src/main/res/layout/activity_live_scan.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <at.plankt0n.streamplay.ui.OneLineOverlay
+        android:id="@+id/overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/recognizedText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|center_horizontal"
+        android:gravity="center"
+        android:textColor="@android:color/white"
+        android:background="#80000000"
+        android:padding="16dp" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,4 +153,8 @@
     <string name="settings_use_spotify_meta">Use Spotify Meta</string>
     <string name="settings_spotify_api_key">Spotify API Key</string>
     <string name="settings_spotify_secret_key">Spotify Secret Key</string>
+    <string name="scan">Scan</string>
+    <string name="scan_permission_denied">Camera permission denied</string>
+    <string name="scan_failed">Scan failed</string>
+    <string name="scan_no_text">No text found</string>
 </resources>


### PR DESCRIPTION
## Summary
- use CameraX for live ML Kit text recognition confined to a single-line overlay
- launch LiveScanActivity from settings dialogs to fill fields without taking photos
- populate open dialog fields with scanned text so results appear immediately
- show recognized text during scanning and require a tap to confirm
- narrow the scan strip to reduce accidental matches
- crop camera frames so detection ignores blurred areas
- filter recognized text to the allowed region instead of modifying ImageProxy
- align scan rectangle with image rotation and require lines to fall completely inside it
- keep the longest recognized string to prevent flickering between partial results
- refresh live results each frame instead of only when longer, avoiding garbled strings
- stabilize recognition by requiring the same text across multiple frames before updating
- accept lines that overlap the scan strip so valid text is still recognized

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cd82c420832fa314d6cff758adb7