### PR TITLE
Add configurable delay for volume slider auto-hide

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -53,4 +53,7 @@ object Keys {
 
     const val CONNECTED_BANNER_DURATION_MS: Long = 1000L
 
+    const val VOLUME_SLIDER_INITIAL_HIDE_DELAY_MS: Long = 5000L
+    const val VOLUME_SLIDER_POST_ADJUST_HIDE_DELAY_MS: Long = 3000L
+
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -538,13 +538,16 @@ class PlayerFragment : Fragment() {
             previousContent?.visibility = View.VISIBLE
             volumeSlider = null
         }
-        handler.postDelayed(dismissRunnable, 5000)
+        handler.postDelayed(dismissRunnable, Keys.VOLUME_SLIDER_INITIAL_HIDE_DELAY_MS)
 
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 if (!fromUser) return
                 handler.removeCallbacks(dismissRunnable)
-                handler.postDelayed(dismissRunnable, 5000)
+                handler.postDelayed(
+                    dismissRunnable,
+                    Keys.VOLUME_SLIDER_POST_ADJUST_HIDE_DELAY_MS
+                )
                 audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, progress, 0)
                 if (progress == 0) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
@@ -563,7 +566,10 @@ class PlayerFragment : Fragment() {
 
             override fun onStopTrackingTouch(seekBar: SeekBar?) {
                 handler.removeCallbacks(dismissRunnable)
-                dismissRunnable.run()
+                handler.postDelayed(
+                    dismissRunnable,
+                    Keys.VOLUME_SLIDER_POST_ADJUST_HIDE_DELAY_MS
+                )
             }
         })
     }


### PR DESCRIPTION
## Summary
- keep volume slider open for 3s after adjustment
- expose auto-hide delays in Keys.kt for easy tweaking

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afb66102c832f95ad52c814067939