### PR TITLE
Show volume percentage while adjusting volume

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -519,9 +519,11 @@ class PlayerFragment : Fragment() {
         val previousContent = overlayContainer.getChildAt(0)
         previousContent?.visibility = View.INVISIBLE
 
-        val seekBar = LayoutInflater.from(requireContext()).inflate(
+        val sliderLayout = LayoutInflater.from(requireContext()).inflate(
             R.layout.volume_slider_popup, overlayContainer, false
-        ) as SeekBar
+        )
+        val seekBar = sliderLayout.findViewById<SeekBar>(R.id.volume_seekbar)
+        val volumeLabel = sliderLayout.findViewById<TextView>(R.id.volume_percentage)
         volumeSlider = seekBar
 
         val audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -529,12 +531,13 @@ class PlayerFragment : Fragment() {
         seekBar.max = maxVolume
         val currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         seekBar.progress = currentVolume
+        volumeLabel.text = "${currentVolume * 100 / maxVolume}%"
 
-        overlayContainer.addView(seekBar)
+        overlayContainer.addView(sliderLayout)
 
         val handler = Handler(Looper.getMainLooper())
         val dismissRunnable = Runnable {
-            overlayContainer.removeView(seekBar)
+            overlayContainer.removeView(sliderLayout)
             previousContent?.visibility = View.VISIBLE
             volumeSlider = null
         }
@@ -549,6 +552,7 @@ class PlayerFragment : Fragment() {
                     Keys.VOLUME_SLIDER_POST_ADJUST_HIDE_DELAY_MS
                 )
                 audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, progress, 0)
+                volumeLabel.text = "${progress * 100 / maxVolume}%"
                 if (progress == 0) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
                     isMuted = true

--- a/app/src/main/res/layout/volume_slider_popup.xml
+++ b/app/src/main/res/layout/volume_slider_popup.xml
@@ -1,10 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<SeekBar xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/volume_seekbar"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginStart="5mm"
-    android:layout_marginEnd="5mm"
-    android:contentDescription="@string/desc_volume_slider"
-    android:thumb="@drawable/volume_slider_thumb"
-    android:thumbOffset="16dp" />
+    android:layout_height="40dp"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:padding="4dp">
+
+    <TextView
+        android:id="@+id/volume_percentage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:text="50%"
+        android:textColor="@color/primary_text_default_material_dark"
+        android:textSize="12sp" />
+
+    <SeekBar
+        android:id="@+id/volume_seekbar"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:contentDescription="@string/desc_volume_slider"
+        android:thumb="@drawable/volume_slider_thumb"
+        android:thumbOffset="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- display a percentage label alongside the volume slider in the station overlay
- update the label as volume changes so users see the target level

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aff788348832fa6f6b91d7607f6cc