### PR TITLE
Add home screen station shortcuts

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -12,7 +12,10 @@ object Keys {
     const val ACTION_REFRESH_METADATA = "at.plankt0n.streamplay.ACTION_REFRESH_METADATA"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
     const val ACTION_PLAY_STATION = "at.plankt0n.streamplay.PLAY_STATION"
-    const val EXTRA_STATION = "extra_station"
+    const val EXTRA_STATION_UUID = "extra_station_uuid"
+    const val EXTRA_STATION_NAME = "extra_station_name"
+    const val EXTRA_STATION_STREAM_URL = "extra_station_stream_url"
+    const val EXTRA_STATION_ICON_URL = "extra_station_icon_url"
     const val UPDATE_FORCE_TAP_COUNT = 5
 
     const val PREF_AUDIO_FOCUS_MODE = "audio_focus_mode"

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -11,6 +11,8 @@ object Keys {
     const val ACTION_HIDE_COUNTDOWN = "at.plankt0n.streamplay.HIDE_COUNTDOWN"
     const val ACTION_REFRESH_METADATA = "at.plankt0n.streamplay.ACTION_REFRESH_METADATA"
     const val EXTRA_COUNTDOWN_DURATION = "countdown_duration"
+    const val ACTION_PLAY_STATION = "at.plankt0n.streamplay.PLAY_STATION"
+    const val EXTRA_STATION = "extra_station"
     const val UPDATE_FORCE_TAP_COUNT = 5
 
     const val PREF_AUDIO_FOCUS_MODE = "audio_focus_mode"

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -1,15 +1,24 @@
 package at.plankt0n.streamplay
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import at.plankt0n.streamplay.ui.MainPagerFragment
+import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
+import at.plankt0n.streamplay.helper.MediaServiceController
+import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.StreamingService
+import at.plankt0n.streamplay.Keys
+import at.plankt0n.streamplay.ui.MainPagerFragment
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
     private var mainPagerFragment: MainPagerFragment? = null
+    private var shortcutController: MediaServiceController? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -24,11 +33,57 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, mainPagerFragment!!, "mainPager")
                 .commit()
-
+            supportFragmentManager.executePendingTransactions()
         } else {
             mainPagerFragment =
                 supportFragmentManager.findFragmentById(R.id.fragment_container) as? MainPagerFragment
         }
+
+        handleShortcutIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handleShortcutIntent(intent)
+    }
+
+    private fun handleShortcutIntent(intent: Intent?) {
+        if (intent?.action != Keys.ACTION_PLAY_STATION) return
+
+        val station = intent.getParcelableExtra<StationItem>(Keys.EXTRA_STATION) ?: return
+        playStationFromShortcut(station)
+    }
+
+    private fun playStationFromShortcut(station: StationItem) {
+        val list = PreferencesHelper.getStations(this).toMutableList()
+        var index = list.indexOfFirst { it.uuid == station.uuid }
+        if (index == -1) {
+            list.add(station)
+            PreferencesHelper.saveStations(this, list)
+            index = list.size - 1
+        }
+
+        PreferencesHelper.setLastPlayedStreamIndex(this, index)
+
+        val refreshIntent = Intent(this, StreamingService::class.java).apply {
+            action = "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST"
+        }
+        startService(refreshIntent)
+
+        shortcutController = MediaServiceController(this)
+        shortcutController?.initializeAndConnect(
+            onConnected = { controller ->
+                Handler(Looper.getMainLooper()).postDelayed({
+                    val idx = shortcutController?.findIndexByMediaId(station.streamURL) ?: index
+                    shortcutController?.playAtIndex(idx)
+                }, 300)
+            },
+            onPlaybackChanged = {},
+            onStreamIndexChanged = {},
+            onMetadataChanged = {},
+            onTimelineChanged = {}
+        )
+        showPlayerPage()
     }
 
     fun showPlayerPage() {

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -50,7 +50,11 @@ class MainActivity : AppCompatActivity() {
     private fun handleShortcutIntent(intent: Intent?) {
         if (intent?.action != Keys.ACTION_PLAY_STATION) return
 
-        val station = intent.getParcelableExtra<StationItem>(Keys.EXTRA_STATION) ?: return
+        val uuid = intent.getStringExtra(Keys.EXTRA_STATION_UUID) ?: return
+        val name = intent.getStringExtra(Keys.EXTRA_STATION_NAME) ?: return
+        val streamUrl = intent.getStringExtra(Keys.EXTRA_STATION_STREAM_URL) ?: return
+        val iconUrl = intent.getStringExtra(Keys.EXTRA_STATION_ICON_URL) ?: ""
+        val station = StationItem(uuid, name, streamUrl, iconUrl)
         playStationFromShortcut(station)
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -70,6 +70,11 @@ class MainActivity : AppCompatActivity() {
         if (mainPagerFragment?.view != null) {
             playStationFromShortcut(station)
             pendingShortcutStation = null
+        } else {
+            Handler(Looper.getMainLooper()).postDelayed(
+                { maybePlayPendingShortcutStation() },
+                50
+            )
         }
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -19,6 +19,7 @@ class MainActivity : AppCompatActivity() {
 
     private var mainPagerFragment: MainPagerFragment? = null
     private var shortcutController: MediaServiceController? = null
+    private var pendingShortcutStation: StationItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,13 +34,18 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, mainPagerFragment!!, "mainPager")
                 .commit()
-            supportFragmentManager.executePendingTransactions()
         } else {
             mainPagerFragment =
                 supportFragmentManager.findFragmentById(R.id.fragment_container) as? MainPagerFragment
         }
 
+        supportFragmentManager.executePendingTransactions()
         handleShortcutIntent(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        maybePlayPendingShortcutStation()
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -55,7 +61,16 @@ class MainActivity : AppCompatActivity() {
         val streamUrl = intent.getStringExtra(Keys.EXTRA_STATION_STREAM_URL) ?: return
         val iconUrl = intent.getStringExtra(Keys.EXTRA_STATION_ICON_URL) ?: ""
         val station = StationItem(uuid, name, streamUrl, iconUrl)
-        playStationFromShortcut(station)
+        pendingShortcutStation = station
+        maybePlayPendingShortcutStation()
+    }
+
+    private fun maybePlayPendingShortcutStation() {
+        val station = pendingShortcutStation ?: return
+        if (mainPagerFragment?.view != null) {
+            playStationFromShortcut(station)
+            pendingShortcutStation = null
+        }
     }
 
     private fun playStationFromShortcut(station: StationItem) {

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -14,7 +14,8 @@ class StationListAdapter(
     private val stationList: MutableList<StationItem>,
     private val startDrag: (RecyclerView.ViewHolder) -> Unit,
     private val onDataChanged: () -> Unit,
-    private val onPlayClick: (Int) -> Unit
+    private val onPlayClick: (Int) -> Unit,
+    private val onPinToHome: (StationItem) -> Unit
 ) : RecyclerView.Adapter<StationListAdapter.ViewHolder>() {
 
     private var editingPosition: Int = -1
@@ -65,6 +66,10 @@ class StationListAdapter(
 
         holder.playButton.visibility = if (isEditing) View.GONE else View.VISIBLE
         holder.playButton.setOnClickListener { onPlayClick(position) }
+        holder.playButton.setOnLongClickListener {
+            onPinToHome(station)
+            true
+        }
 
         Glide.with(holder.playButton.context)
             .load(station.iconURL)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -36,7 +36,10 @@ import at.plankt0n.streamplay.helper.StationImportHelper
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import at.plankt0n.streamplay.Keys
+import com.bumptech.glide.Glide
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.*
 
 class StationsFragment : Fragment() {
@@ -251,15 +254,35 @@ class StationsFragment : Fragment() {
             putExtra(Keys.EXTRA_STATION_ICON_URL, station.iconURL)
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
-        val icon = IconCompat.createWithResource(context, R.drawable.ic_radio)
-        val shortcut = androidx.core.content.pm.ShortcutInfoCompat.Builder(context, shortcutId)
-            .setShortLabel(station.stationName)
-            .setIcon(icon)
-            .setIntent(intent)
-            .build()
 
-        ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
-        Toast.makeText(context, R.string.toast_shortcut_added, Toast.LENGTH_SHORT).show()
+        lifecycleScope.launch {
+            val bitmap = withContext(Dispatchers.IO) {
+                try {
+                    if (station.iconURL.isNotBlank()) {
+                        Glide.with(context).asBitmap().load(station.iconURL).submit().get()
+                    } else {
+                        null
+                    }
+                } catch (e: Exception) {
+                    null
+                }
+            }
+
+            val icon = if (bitmap != null) {
+                IconCompat.createWithBitmap(bitmap)
+            } else {
+                IconCompat.createWithResource(context, R.drawable.ic_radio)
+            }
+
+            val shortcut = androidx.core.content.pm.ShortcutInfoCompat.Builder(context, shortcutId)
+                .setShortLabel(station.stationName)
+                .setIcon(icon)
+                .setIntent(intent)
+                .build()
+
+            ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+            Toast.makeText(context, R.string.toast_shortcut_added, Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun refreshPlaylist() {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -245,7 +245,10 @@ class StationsFragment : Fragment() {
         val shortcutId = "station_${station.uuid}"
         val intent = Intent(context, MainActivity::class.java).apply {
             action = Keys.ACTION_PLAY_STATION
-            putExtra(Keys.EXTRA_STATION, station)
+            putExtra(Keys.EXTRA_STATION_UUID, station.uuid)
+            putExtra(Keys.EXTRA_STATION_NAME, station.stationName)
+            putExtra(Keys.EXTRA_STATION_STREAM_URL, station.streamURL)
+            putExtra(Keys.EXTRA_STATION_ICON_URL, station.iconURL)
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
         val icon = IconCompat.createWithResource(context, R.drawable.ic_radio)

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -33,6 +33,9 @@ import at.plankt0n.streamplay.MainActivity
 import androidx.viewpager2.widget.ViewPager2
 import androidx.activity.OnBackPressedCallback
 import at.plankt0n.streamplay.helper.StationImportHelper
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import at.plankt0n.streamplay.Keys
 import kotlinx.coroutines.launch
 import java.util.*
 
@@ -135,8 +138,10 @@ class StationsFragment : Fragment() {
             itemTouchHelper.startDrag(holder)
         }, {
             refreshPlaylist()
-        }) { index ->
+        }, { index ->
             mediaServiceController.playAtIndex(index)
+        }) { station ->
+            pinStationToHome(station)
         }
         recyclerView.adapter = adapter
         itemTouchHelper.attachToRecyclerView(recyclerView)
@@ -228,6 +233,30 @@ class StationsFragment : Fragment() {
             .create()
 
         dialog.show()
+    }
+
+    private fun pinStationToHome(station: StationItem) {
+        val context = requireContext()
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(context)) {
+            Toast.makeText(context, "Pinning shortcuts not supported", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val shortcutId = "station_${station.uuid}"
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = Keys.ACTION_PLAY_STATION
+            putExtra(Keys.EXTRA_STATION, station)
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val icon = IconCompat.createWithResource(context, R.drawable.ic_radio)
+        val shortcut = androidx.core.content.pm.ShortcutInfoCompat.Builder(context, shortcutId)
+            .setShortLabel(station.stationName)
+            .setIcon(icon)
+            .setIntent(intent)
+            .build()
+
+        ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+        Toast.makeText(context, R.string.toast_shortcut_added, Toast.LENGTH_SHORT).show()
     }
 
     private fun refreshPlaylist() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
 
     <!-- Stations Fragment play button -->
     <string name="desc_button_play_station">Play this station</string>
+    <string name="toast_shortcut_added">Shortcut added to home screen</string>
 
     <!-- Discover Fragment -->
     <string name="discover_title">Discover</string>


### PR DESCRIPTION
## Summary
- allow pinning stations to the Android home screen
- long-press station play button to create shortcut
- launching shortcut restores missing station and starts playback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3ac95fd8832f81dbc5258c3df718