### PR TITLE
Move Exoplayer banner setting and guard bottom sheet

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
@@ -15,6 +15,10 @@ import at.plankt0n.streamplay.ui.MetaLogFragment
 
 class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
 
+    companion object {
+        const val TAG = "MediaItemOptionsBottomSheet"
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -622,8 +622,9 @@ class PlayerFragment : Fragment() {
     }
 
     private fun showBottomSheet() {
-        val bottomSheet = MediaItemOptionsBottomSheet()
-        bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+        val tag = MediaItemOptionsBottomSheet.TAG
+        if (parentFragmentManager.findFragmentByTag(tag) != null) return
+        MediaItemOptionsBottomSheet().show(parentFragmentManager, tag)
     }
 
     fun enableMarquee(vararg views: TextView) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -121,7 +121,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         key = "show_exoplayer_banner"
         title = getString(R.string.settings_exoplayer_infobanner)
         setDefaultValue(true)
-        category = SettingsCategory.UI
+        category = SettingsCategory.PLAYER
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 


### PR DESCRIPTION
## Summary
- Place the "Show Exoplayer Infobanner" toggle under Player settings.
- Prevent multiple bottom sheets from stacking by checking for an existing instance before showing.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4975ecd8832f8205186b2b3e5e25