### PR TITLE
Refactor overlay tint handling for player controls

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -24,6 +24,7 @@ import android.widget.ViewFlipper
 import android.widget.SeekBar
 import android.widget.FrameLayout
 import android.graphics.Color
+import android.content.res.ColorStateList
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -45,6 +46,7 @@ import at.plankt0n.streamplay.viewmodel.UITrackInfo
 import at.plankt0n.streamplay.data.MetaLogEntry
 import at.plankt0n.streamplay.Keys
 import androidx.core.graphics.ColorUtils
+import androidx.core.widget.ImageViewCompat
 import androidx.media3.common.Player
 import com.bumptech.glide.Glide
 import com.google.android.material.imageview.ShapeableImageView
@@ -129,6 +131,7 @@ class PlayerFragment : Fragment() {
 
     var isMuted = false
     private var showingMetaCover = true
+    private var currentForeground: Int = Color.WHITE
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -503,23 +506,23 @@ class PlayerFragment : Fragment() {
 
     private fun updateOverlayColors(color: Int) {
         val luminance = ColorUtils.calculateLuminance(color)
-        val foreground = if (luminance > 0.5) Color.BLACK else Color.WHITE
+        currentForeground = if (luminance > 0.5) Color.BLACK else Color.WHITE
 
-        stationNameTextView.setTextColor(foreground)
+        stationNameTextView.setTextColor(currentForeground)
 
-        view?.findViewById<TextView>(R.id.meta_overlay_Title)?.setTextColor(foreground)
-        view?.findViewById<TextView>(R.id.meta_overlay_Artist)?.setTextColor(foreground)
-        view?.findViewById<TextView>(R.id.meta_overlay_Album)?.setTextColor(foreground)
-        view?.findViewById<TextView>(R.id.meta_overlay_Genre)?.setTextColor(foreground)
+        view?.findViewById<TextView>(R.id.meta_overlay_Title)?.setTextColor(currentForeground)
+        view?.findViewById<TextView>(R.id.meta_overlay_Artist)?.setTextColor(currentForeground)
+        view?.findViewById<TextView>(R.id.meta_overlay_Album)?.setTextColor(currentForeground)
+        view?.findViewById<TextView>(R.id.meta_overlay_Genre)?.setTextColor(currentForeground)
 
-        buttonBack.setColorFilter(foreground)
-        playPauseButton.setColorFilter(foreground)
-        buttonForward.setColorFilter(foreground)
-        buttonMute.setColorFilter(foreground)
-        buttonShare.setColorFilter(foreground)
-        buttonMenu.setColorFilter(foreground)
-        buttonSpotify.setColorFilter(foreground)
-        buttonManualLog.setColorFilter(foreground)
+        ImageViewCompat.setImageTintList(buttonBack, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(playPauseButton, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonForward, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonMute, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonShare, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonMenu, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonSpotify, ColorStateList.valueOf(currentForeground))
+        ImageViewCompat.setImageTintList(buttonManualLog, ColorStateList.valueOf(currentForeground))
     }
 
     private fun updateOverlayUI(index: Int) {
@@ -541,6 +544,7 @@ class PlayerFragment : Fragment() {
     private fun updatePlayPauseIcon(isPlaying: Boolean) {
         val iconRes = if (isPlaying) R.drawable.ic_button_pause else R.drawable.ic_button_play
         playPauseButton.setImageResource(iconRes)
+        ImageViewCompat.setImageTintList(playPauseButton, ColorStateList.valueOf(currentForeground))
     }
 
     private fun showVolumePopup(@Suppress("UNUSED_PARAMETER") anchor: View) {

--- a/app/src/main/res/layout/fragment_player_ui_overlay.xml
+++ b/app/src/main/res/layout/fragment_player_ui_overlay.xml
@@ -74,8 +74,7 @@
             android:layout_height="48dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/desc_button_back"
-            android:src="@drawable/ic_button_back"
-            app:tint="@color/primary_material_light" />
+            android:src="@drawable/ic_button_back" />
 
         <ImageButton
             android:id="@+id/button_play_pause"
@@ -86,8 +85,7 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/desc_button_play_pause"
             android:scaleType="fitXY"
-            android:src="@drawable/ic_button_play"
-            app:tint="@color/primary_material_light" />
+            android:src="@drawable/ic_button_play" />
 
         <ImageButton
             android:id="@+id/button_forward"
@@ -95,8 +93,7 @@
             android:layout_height="48dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/desc_button_forward"
-            android:src="@drawable/ic_button_forward"
-            app:tint="@color/primary_material_light" />
+            android:src="@drawable/ic_button_forward" />
     </LinearLayout>
 
     <!-- Station Info Overlay -->


### PR DESCRIPTION
## Summary
- Track current overlay foreground color in `PlayerFragment`
- Tint player buttons via `ImageViewCompat` and reapply tint after icon updates
- Remove hardcoded button tints in `fragment_player_ui_overlay`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8b2ed294832f9960958765959a50