### PR TITLE
Ensure overlay colors update on every cover switch

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -98,9 +98,9 @@ object LiveCoverHelper {
                                             }
                                         }
                                         animator.start()
-                                        onNewColor(smoothColor)
-                                        onNewEffect(effect)
                                     }
+                                    onNewColor(smoothColor)
+                                    onNewEffect(effect)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- always invoke new color/effect callbacks after loading cover art so UI overlay colors refresh on each cover change
- keep background animation limited to actual color/effect transitions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdda17678832f888882be07198922