### PR TITLE
Add GIF and SVG icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ StreamPlay is a lightweight webstream player for Android. It features a cover-ba
 - Cover UI with Spotify-sourced artwork
 - Audio session integration for media controls
 - Metadata logging via Metalog
+- Animated GIF and SVG station icons supported in both shortcut bar and cover view
 
 ## Planned Features
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     id("kotlin-parcelize")
+    kotlin("kapt")
 }
 
 android {
@@ -76,6 +77,8 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.caverock:androidsvg:1.4")
+    kapt("com.github.bumptech.glide:compiler:4.16.0")
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/DiscoverAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/DiscoverAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
 import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.svg.SvgSoftwareLayerSetter
 
 class DiscoverAdapter(
     private val items: List<StationItem>,
@@ -35,6 +36,7 @@ class DiscoverAdapter(
             .load(item.iconURL)
             .placeholder(R.drawable.ic_placeholder_logo)
             .error(R.drawable.ic_stationcover_placeholder)
+            .listener(SvgSoftwareLayerSetter())
             .into(holder.image)
         holder.itemView.setOnClickListener { onClick(item) }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
 import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.svg.SvgSoftwareLayerSetter
 
 class SearchResultAdapter(
     private val searchResults: List<StationItem>,
@@ -38,6 +39,7 @@ class SearchResultAdapter(
         Glide.with(holder.imageLogo.context)
             .load(result.iconURL)
             .placeholder(R.drawable.ic_stationcover_placeholder)
+            .listener(SvgSoftwareLayerSetter())
             .into(holder.imageLogo)
 
         holder.itemView.setOnClickListener {

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.ShortcutItem
 import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.svg.SvgSoftwareLayerSetter
 
 class ShortcutAdapter(
     private val onClick: (ShortcutItem) -> Unit
@@ -44,6 +45,7 @@ class ShortcutAdapter(
             .placeholder(R.drawable.ic_placeholder_logo)
             .error(R.drawable.ic_radio)
             .fallback(R.drawable.ic_radio)
+            .listener(SvgSoftwareLayerSetter())
             .into(holder.iconImageView)
 
         holder.itemView.setOnClickListener { onClick(item) }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.svg.SvgSoftwareLayerSetter
 
 class StationListAdapter(
     private val stationList: MutableList<StationItem>,
@@ -76,6 +77,7 @@ class StationListAdapter(
             .placeholder(R.drawable.ic_stationcover_placeholder)
             .error(R.drawable.ic_stationcover_placeholder)
             .fallback(R.drawable.ic_stationcover_placeholder)
+            .listener(SvgSoftwareLayerSetter())
             .into(holder.playButton)
 
         val context = holder.itemView.context

--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -3,18 +3,21 @@ package at.plankt0n.streamplay.helper
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.PictureDrawable
 import android.view.View
 import android.widget.ImageView
 import at.plankt0n.streamplay.R
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.BitmapImageViewTarget
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import androidx.palette.graphics.Palette
+import com.bumptech.glide.load.resource.gif.GifDrawable
 import jp.wasabeef.glide.transformations.BlurTransformation
 
 object LiveCoverHelper {
@@ -43,16 +46,29 @@ object LiveCoverHelper {
         onNewEffect: (BackgroundEffect) -> Unit
     ) {
         Glide.with(context)
-            .asBitmap()
             .load(imageUrl)
             .placeholder(R.drawable.ic_placeholder_logo)
             .error(R.drawable.ic_stationcover_placeholder)
-            .into(object : BitmapImageViewTarget(imageView) {
-                override fun setResource(resource: Bitmap?) {
-                    super.setResource(resource)
-                    resource?.let { bitmap ->
+            .into(object : CustomTarget<Drawable>() {
+                override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+                    imageView.setImageDrawable(resource)
+
+                    val bitmap: Bitmap? = when (resource) {
+                        is BitmapDrawable -> resource.bitmap
+                        is GifDrawable -> {
+                            resource.start()
+                            resource.firstFrame
+                        }
+                        is PictureDrawable -> {
+                            imageView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                            drawableToBitmap(resource)
+                        }
+                        else -> null
+                    }
+
+                    bitmap?.let { bmp ->
                         if (effect == BackgroundEffect.BLUR) {
-                            Palette.from(bitmap).generate { palette ->
+                            Palette.from(bmp).generate { palette ->
                                 val dominantColor = palette?.getDominantColor(defaultColor) ?: defaultColor
 
                                 val hsv = FloatArray(3)
@@ -70,21 +86,17 @@ object LiveCoverHelper {
                                             .transform(BlurTransformation(25, 3))
                                     )
                                     .into(object : CustomTarget<Bitmap>() {
-                                        override fun onResourceReady(
-                                            resource: Bitmap,
-                                            transition: Transition<in Bitmap>?,
-                                        ) {
-                                            backgroundTarget.background =
-                                                BitmapDrawable(context.resources, resource)
+                                        override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+                                            backgroundTarget.background = BitmapDrawable(context.resources, resource)
                                             onNewColor(smoothColor)
                                             onNewEffect(effect)
                                         }
 
-                                        override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
+                                        override fun onLoadCleared(placeholder: Drawable?) {}
                                     })
                             }
                         } else {
-                            Palette.from(bitmap).generate { palette ->
+                            Palette.from(bmp).generate { palette ->
                                 palette?.let {
                                     val dominantColor = it.getDominantColor(defaultColor)
 
@@ -94,7 +106,6 @@ object LiveCoverHelper {
                                     hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
                                     val smoothColor = Color.HSVToColor(hsv)
 
-                                    // Nur animieren, wenn sich Farbe oder Effekt ändert
                                     if (lastColor != smoothColor || lastEffect != effect) {
                                         val animator = ValueAnimator.ofArgb(
                                             lastColor ?: defaultColor,
@@ -116,7 +127,20 @@ object LiveCoverHelper {
                         }
                     }
                 }
+
+                override fun onLoadCleared(placeholder: Drawable?) {
+                    imageView.setImageDrawable(placeholder)
+                }
             })
+    }
+
+    private fun drawableToBitmap(drawable: PictureDrawable): Bitmap {
+        val width = drawable.intrinsicWidth.takeIf { it > 0 } ?: 512
+        val height = drawable.intrinsicHeight.takeIf { it > 0 } ?: 512
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawPicture(drawable.picture)
+        return bitmap
     }
 
     fun createGradient(color: Int, effect: BackgroundEffect): GradientDrawable {

--- a/app/src/main/java/at/plankt0n/streamplay/svg/SvgBitmapTranscoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/svg/SvgBitmapTranscoder.kt
@@ -1,0 +1,23 @@
+package at.plankt0n.streamplay.svg
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.SVG
+
+class SvgBitmapTranscoder : ResourceTranscoder<SVG, Bitmap> {
+    override fun transcode(toTranscode: Resource<SVG>, options: Options): Resource<Bitmap>? {
+        val svg = toTranscode.get()
+        val picture = svg.renderToPicture()
+        val width = svg.documentWidth.toInt().takeIf { it > 0 } ?: picture.width
+        val height = svg.documentHeight.toInt().takeIf { it > 0 } ?: picture.height
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawPicture(picture)
+        return SimpleResource(bitmap)
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/svg/SvgDecoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/svg/SvgDecoder.kt
@@ -1,0 +1,27 @@
+package at.plankt0n.streamplay.svg
+
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.SVGParseException
+import java.io.IOException
+import java.io.InputStream
+import com.bumptech.glide.request.target.Target
+
+class SvgDecoder : ResourceDecoder<InputStream, SVG> {
+    override fun handles(source: InputStream, options: Options): Boolean = true
+
+    @Throws(IOException::class)
+    override fun decode(source: InputStream, width: Int, height: Int, options: Options): Resource<SVG> {
+        return try {
+            val svg = SVG.getFromInputStream(source)
+            if (width != Target.SIZE_ORIGINAL) svg.documentWidth = width.toFloat()
+            if (height != Target.SIZE_ORIGINAL) svg.documentHeight = height.toFloat()
+            SimpleResource(svg)
+        } catch (ex: SVGParseException) {
+            throw IOException("Cannot load SVG from stream", ex)
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/svg/SvgDrawableTranscoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/svg/SvgDrawableTranscoder.kt
@@ -1,0 +1,18 @@
+package at.plankt0n.streamplay.svg
+
+import android.graphics.Picture
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.SVG
+
+class SvgDrawableTranscoder : ResourceTranscoder<SVG, PictureDrawable> {
+    override fun transcode(toTranscode: Resource<SVG>, options: Options): Resource<PictureDrawable>? {
+        val svg = toTranscode.get()
+        val picture: Picture = svg.renderToPicture()
+        val drawable = PictureDrawable(picture)
+        return SimpleResource(drawable)
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/svg/SvgModule.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/svg/SvgModule.kt
@@ -1,0 +1,23 @@
+package at.plankt0n.streamplay.svg
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+import com.caverock.androidsvg.SVG
+import java.io.InputStream
+
+@GlideModule
+class SvgModule : AppGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry
+            .register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder())
+            .register(SVG::class.java, Bitmap::class.java, SvgBitmapTranscoder())
+            .append(InputStream::class.java, SVG::class.java, SvgDecoder())
+    }
+
+    override fun isManifestParsingEnabled(): Boolean = false
+}

--- a/app/src/main/java/at/plankt0n/streamplay/svg/SvgSoftwareLayerSetter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/svg/SvgSoftwareLayerSetter.kt
@@ -1,0 +1,34 @@
+package at.plankt0n.streamplay.svg
+
+import android.graphics.drawable.PictureDrawable
+import android.widget.ImageView
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.ImageViewTarget
+import com.bumptech.glide.request.target.Target
+
+class SvgSoftwareLayerSetter : RequestListener<PictureDrawable> {
+    override fun onLoadFailed(
+        e: GlideException?,
+        model: Any?,
+        target: Target<PictureDrawable>,
+        isFirstResource: Boolean
+    ): Boolean {
+        val view = (target as ImageViewTarget<*>).view
+        view.setLayerType(ImageView.LAYER_TYPE_NONE, null)
+        return false
+    }
+
+    override fun onResourceReady(
+        resource: PictureDrawable,
+        model: Any?,
+        target: Target<PictureDrawable>,
+        dataSource: DataSource,
+        isFirstResource: Boolean
+    ): Boolean {
+        val view = (target as ImageViewTarget<*>).view
+        view.setLayerType(ImageView.LAYER_TYPE_SOFTWARE, null)
+        return false
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -52,6 +52,7 @@ import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
 import android.widget.Toast
 import kotlin.math.min
+import at.plankt0n.streamplay.svg.SvgSoftwareLayerSetter
 
 class PlayerFragment : Fragment() {
 
@@ -421,6 +422,7 @@ class PlayerFragment : Fragment() {
                     .load(R.drawable.placeholder_spotify_dark)
                     .placeholder(R.drawable.placeholder_spotify_dark)
                     .error(R.drawable.placeholder_spotify_dark)
+                    .listener(SvgSoftwareLayerSetter())
                     .into(stationIconView!!)
 
                 return@observe
@@ -560,12 +562,14 @@ class PlayerFragment : Fragment() {
                     .load(trackInfo.bestCoverUrl)
                     .placeholder(R.drawable.ic_placeholder_logo)
                     .error(R.drawable.ic_stationcover_placeholder)
+                    .listener(SvgSoftwareLayerSetter())
                     .into(stationIconView!!)
             } else {
                 Glide.with(requireContext())
                     .load(defaultIconUrl)
                     .placeholder(R.drawable.ic_placeholder_logo)
                     .error(R.drawable.ic_stationcover_placeholder)
+                    .listener(SvgSoftwareLayerSetter())
                     .into(stationIconView!!)
             }
 
@@ -608,6 +612,7 @@ class PlayerFragment : Fragment() {
             .load(iconUrl)
             .placeholder(R.drawable.placeholder_spotify_dark)
             .error(R.drawable.placeholder_spotify_dark)
+            .listener(SvgSoftwareLayerSetter())
             .into(stationIconImageView)
     }
 


### PR DESCRIPTION
## Summary
- Support animated GIF and SVG station icons throughout the app
- Animate GIFs for large cover images and load SVGs via Glide module
- Document new image format support

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0ca58c5c832fb1ac499373c0a3ae