### PR TITLE
Add SVG icon support and animated GIF covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ StreamPlay is a lightweight webstream player for Android. It features a cover-ba
 
 - Playback of online audio streams
 - Cover UI with Spotify-sourced artwork
+- Animated cover images when using GIFs
+- Support for SVG station icons
 - Audio session integration for media controls
 - Metadata logging via Metalog
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     id("kotlin-parcelize")
+    id("kotlin-kapt")
 }
 
 android {
@@ -71,13 +72,12 @@ dependencies {
         implementation("androidx.work:work-runtime-ktx:2.9.0")
 
         // Gson
-        implementation("com.google.code.gson:gson:2.10.1")
-    //Glide
+    implementation("com.google.code.gson:gson:2.10.1")
+    // Glide
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    kapt("com.github.bumptech.glide:compiler:4.16.0")
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
-
-
-
+    implementation("com.caverock:androidsvg:1.4")
 
 }

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgDecoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgDecoder.kt
@@ -1,0 +1,31 @@
+package at.plankt0n.streamplay.glide
+
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.caverock.androidsvg.SVG
+import java.io.InputStream
+
+/**
+ * Decodes an [InputStream] into an [SVG] object using the AndroidSVG library.
+ */
+class SvgDecoder : ResourceDecoder<InputStream, SVG> {
+
+    override fun handles(source: InputStream, options: Options): Boolean = true
+
+    override fun decode(
+        source: InputStream,
+        width: Int,
+        height: Int,
+        options: Options
+    ): Resource<SVG>? {
+        return try {
+            val svg = SVG.getFromInputStream(source)
+            SimpleResource(svg)
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgDrawableTranscoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgDrawableTranscoder.kt
@@ -1,0 +1,25 @@
+package at.plankt0n.streamplay.glide
+
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.SVG
+
+/**
+ * Converts an [SVG] object into a [PictureDrawable] so it can be displayed in an [ImageView].
+ */
+class SvgDrawableTranscoder : ResourceTranscoder<SVG, PictureDrawable> {
+
+    override fun transcode(
+        toTranscode: Resource<SVG>,
+        options: Options
+    ): Resource<PictureDrawable>? {
+        val svg = toTranscode.get()
+        val picture = svg.renderToPicture()
+        val drawable = PictureDrawable(picture)
+        return SimpleResource(drawable)
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgModule.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgModule.kt
@@ -1,0 +1,25 @@
+package at.plankt0n.streamplay.glide
+
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+import com.caverock.androidsvg.SVG
+import java.io.InputStream
+
+/**
+ * Registers SVG handling components for Glide.
+ */
+@GlideModule
+class SvgModule : AppGlideModule() {
+
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry
+            .register(SVG::class.java, android.graphics.drawable.PictureDrawable::class.java, SvgDrawableTranscoder())
+            .append(InputStream::class.java, SVG::class.java, SvgDecoder())
+    }
+
+    override fun isManifestParsingEnabled(): Boolean = false
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgSoftwareLayerSetter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgSoftwareLayerSetter.kt
@@ -1,0 +1,36 @@
+package at.plankt0n.streamplay.glide
+
+import android.graphics.drawable.PictureDrawable
+import android.view.View
+import android.widget.ImageView
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.ImageViewTarget
+import com.bumptech.glide.request.target.Target
+
+/**
+ * Ensures that SVGs are rendered using a software layer.
+ */
+class SvgSoftwareLayerSetter : RequestListener<PictureDrawable> {
+
+    override fun onLoadFailed(
+        e: GlideException?,
+        model: Any?,
+        target: Target<PictureDrawable>,
+        isFirstResource: Boolean
+    ): Boolean = false
+
+    override fun onResourceReady(
+        resource: PictureDrawable,
+        model: Any?,
+        target: Target<PictureDrawable>,
+        dataSource: DataSource,
+        isFirstResource: Boolean
+    ): Boolean {
+        val view = (target as? ImageViewTarget<*>)?.view as? ImageView
+        view?.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+        return false
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -42,6 +42,109 @@ object LiveCoverHelper {
         onNewColor: (Int) -> Unit,
         onNewEffect: (BackgroundEffect) -> Unit
     ) {
+        fun processBitmap(bitmap: Bitmap) {
+            if (effect == BackgroundEffect.BLUR) {
+                Palette.from(bitmap).generate { palette ->
+                    val dominantColor = palette?.getDominantColor(defaultColor) ?: defaultColor
+                    val hsv = FloatArray(3)
+                    Color.colorToHSV(dominantColor, hsv)
+                    hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
+                    hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
+                    val smoothColor = Color.HSVToColor(hsv)
+
+                    Glide.with(context)
+                        .asBitmap()
+                        .load(imageUrl)
+                        .apply(
+                            RequestOptions()
+                                .centerCrop()
+                                .transform(BlurTransformation(25, 3))
+                        )
+                        .into(object : CustomTarget<Bitmap>() {
+                            override fun onResourceReady(
+                                resource: Bitmap,
+                                transition: Transition<in Bitmap>?,
+                            ) {
+                                backgroundTarget.background =
+                                    BitmapDrawable(context.resources, resource)
+                                onNewColor(smoothColor)
+                                onNewEffect(effect)
+                            }
+
+                            override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
+                        })
+                }
+            } else {
+                Palette.from(bitmap).generate { palette ->
+                    palette?.let {
+                        val dominantColor = it.getDominantColor(defaultColor)
+                        val hsv = FloatArray(3)
+                        Color.colorToHSV(dominantColor, hsv)
+                        hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
+                        hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
+                        val smoothColor = Color.HSVToColor(hsv)
+
+                        if (lastColor != smoothColor || lastEffect != effect) {
+                            val animator = ValueAnimator.ofArgb(
+                                lastColor ?: defaultColor,
+                                smoothColor
+                            ).apply {
+                                duration = 400
+                                addUpdateListener { anim ->
+                                    val color = anim.animatedValue as Int
+                                    val gradient = createGradient(color, effect)
+                                    backgroundTarget.background = gradient
+                                }
+                            }
+                            animator.start()
+                        }
+                        onNewColor(smoothColor)
+                        onNewEffect(effect)
+                    }
+                }
+            }
+        }
+
+        val lowerUrl = imageUrl.lowercase()
+        when {
+            lowerUrl.endsWith(".gif") -> {
+                Glide.with(context)
+                    .asGif()
+                    .load(imageUrl)
+                    .placeholder(R.drawable.ic_placeholder_logo)
+                    .error(R.drawable.ic_stationcover_placeholder)
+                    .into(imageView)
+
+                Glide.with(context)
+                    .asBitmap()
+                    .load(imageUrl)
+                    .placeholder(R.drawable.ic_placeholder_logo)
+                    .error(R.drawable.ic_stationcover_placeholder)
+                    .into(object : CustomTarget<Bitmap>() {
+                        override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+                            processBitmap(resource)
+                        }
+                        override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
+                    })
+                return
+            }
+            lowerUrl.endsWith(".svg") -> {
+                Glide.with(context)
+                    .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                    .listener(at.plankt0n.streamplay.glide.SvgSoftwareLayerSetter())
+                    .load(imageUrl)
+                    .placeholder(R.drawable.ic_placeholder_logo)
+                    .error(R.drawable.ic_stationcover_placeholder)
+                    .into(imageView)
+
+                val gradient = createGradient(defaultColor, effect)
+                backgroundTarget.background = gradient
+                onNewColor(defaultColor)
+                onNewEffect(effect)
+                return
+            }
+        }
+
         Glide.with(context)
             .asBitmap()
             .load(imageUrl)
@@ -51,69 +154,7 @@ object LiveCoverHelper {
                 override fun setResource(resource: Bitmap?) {
                     super.setResource(resource)
                     resource?.let { bitmap ->
-                        if (effect == BackgroundEffect.BLUR) {
-                            Palette.from(bitmap).generate { palette ->
-                                val dominantColor = palette?.getDominantColor(defaultColor) ?: defaultColor
-
-                                val hsv = FloatArray(3)
-                                Color.colorToHSV(dominantColor, hsv)
-                                hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
-                                hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
-                                val smoothColor = Color.HSVToColor(hsv)
-
-                                Glide.with(context)
-                                    .asBitmap()
-                                    .load(imageUrl)
-                                    .apply(
-                                        RequestOptions()
-                                            .centerCrop()
-                                            .transform(BlurTransformation(25, 3))
-                                    )
-                                    .into(object : CustomTarget<Bitmap>() {
-                                        override fun onResourceReady(
-                                            resource: Bitmap,
-                                            transition: Transition<in Bitmap>?,
-                                        ) {
-                                            backgroundTarget.background =
-                                                BitmapDrawable(context.resources, resource)
-                                            onNewColor(smoothColor)
-                                            onNewEffect(effect)
-                                        }
-
-                                        override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
-                                    })
-                            }
-                        } else {
-                            Palette.from(bitmap).generate { palette ->
-                                palette?.let {
-                                    val dominantColor = it.getDominantColor(defaultColor)
-
-                                    val hsv = FloatArray(3)
-                                    Color.colorToHSV(dominantColor, hsv)
-                                    hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
-                                    hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
-                                    val smoothColor = Color.HSVToColor(hsv)
-
-                                    // Nur animieren, wenn sich Farbe oder Effekt ändert
-                                    if (lastColor != smoothColor || lastEffect != effect) {
-                                        val animator = ValueAnimator.ofArgb(
-                                            lastColor ?: defaultColor,
-                                            smoothColor
-                                        ).apply {
-                                            duration = 400
-                                            addUpdateListener { anim ->
-                                                val color = anim.animatedValue as Int
-                                                val gradient = createGradient(color, effect)
-                                                backgroundTarget.background = gradient
-                                            }
-                                        }
-                                        animator.start()
-                                    }
-                                    onNewColor(smoothColor)
-                                    onNewEffect(effect)
-                                }
-                            }
-                        }
+                        processBitmap(bitmap)
                     }
                 }
             })

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -555,15 +555,22 @@ class PlayerFragment : Fragment() {
                 albumTextView?.text = getString(R.string.unknown_album)
             }
 
-            if (coverMode == CoverMode.META && !trackInfo.bestCoverUrl.isNullOrBlank()) {
+            val iconUrlToLoad = if (coverMode == CoverMode.META && !trackInfo.bestCoverUrl.isNullOrBlank()) {
+                trackInfo.bestCoverUrl
+            } else {
+                defaultIconUrl
+            }
+            if (iconUrlToLoad.lowercase().endsWith(".svg")) {
                 Glide.with(requireContext())
-                    .load(trackInfo.bestCoverUrl)
+                    .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                    .listener(at.plankt0n.streamplay.glide.SvgSoftwareLayerSetter())
+                    .load(iconUrlToLoad)
                     .placeholder(R.drawable.ic_placeholder_logo)
                     .error(R.drawable.ic_stationcover_placeholder)
                     .into(stationIconView!!)
             } else {
                 Glide.with(requireContext())
-                    .load(defaultIconUrl)
+                    .load(iconUrlToLoad)
                     .placeholder(R.drawable.ic_placeholder_logo)
                     .error(R.drawable.ic_stationcover_placeholder)
                     .into(stationIconView!!)
@@ -604,11 +611,21 @@ class PlayerFragment : Fragment() {
         val iconUrl = extras.getString("EXTRA_ICON_URL") ?: ""
 
         stationNameTextView.text = stationName
-        Glide.with(stationIconImageView)
-            .load(iconUrl)
-            .placeholder(R.drawable.placeholder_spotify_dark)
-            .error(R.drawable.placeholder_spotify_dark)
-            .into(stationIconImageView)
+        if (iconUrl.lowercase().endsWith(".svg")) {
+            Glide.with(stationIconImageView)
+                .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                .listener(at.plankt0n.streamplay.glide.SvgSoftwareLayerSetter())
+                .load(iconUrl)
+                .placeholder(R.drawable.placeholder_spotify_dark)
+                .error(R.drawable.placeholder_spotify_dark)
+                .into(stationIconImageView)
+        } else {
+            Glide.with(stationIconImageView)
+                .load(iconUrl)
+                .placeholder(R.drawable.placeholder_spotify_dark)
+                .error(R.drawable.placeholder_spotify_dark)
+                .into(stationIconImageView)
+        }
     }
 
     private fun updatePlayPauseIcon(isPlaying: Boolean) {


### PR DESCRIPTION
## Summary
- Allow SVG station icons by registering a custom Glide SVG decoder and using it when loading icons
- Animate GIF cover images and handle SVG covers in `LiveCoverHelper`
- Document GIF animation and SVG icon support in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f20210f44832faf40e99301d5a4dc