### PR TITLE
Add personal JSON startup sync option

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -22,6 +22,7 @@ object Keys {
     const val PREF_COVER_ANIMATION_STYLE = "cover_animation_style"
 
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
+    const val PREF_PERSONAL_SYNC_STARTUP = "personal_sync_at_startup"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -4,16 +4,20 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
+import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.PreferencesHelper
+import at.plankt0n.streamplay.helper.StationImportHelper
 import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.ui.MainPagerFragment
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
@@ -24,6 +28,19 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
+            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
+            Log.i("StreamPlay", "Syncing personal JSON at startup")
+            runBlocking {
+                try {
+                    StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
+                } catch (e: Exception) {
+                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
+                }
+            }
+        }
 
         setContentView(R.layout.activity_main)
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -4,20 +4,16 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
-import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import at.plankt0n.streamplay.data.StationItem
 import at.plankt0n.streamplay.helper.GitHubUpdateChecker
 import at.plankt0n.streamplay.helper.MediaServiceController
 import at.plankt0n.streamplay.helper.PreferencesHelper
-import at.plankt0n.streamplay.helper.StationImportHelper
 import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.ui.MainPagerFragment
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
@@ -28,19 +24,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
-            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
-            Log.i("StreamPlay", "Syncing personal JSON at startup")
-            runBlocking {
-                try {
-                    StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
-                } catch (e: Exception) {
-                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
-                }
-            }
-        }
 
         setContentView(R.layout.activity_main)
 

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,6 +1,7 @@
 package at.plankt0n.streamplay
 
 import android.app.Application
+import android.content.Intent
 import android.util.Log
 import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
@@ -15,19 +16,32 @@ class StreamPlayApplication : Application() {
         if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
             val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
             Log.i("StreamPlay", "Syncing personal JSON at startup")
+            var refreshNeeded = false
             runBlocking {
                 try {
                     val result = StationImportHelper.importStationsFromUrl(
                         this@StreamPlayApplication,
                         url,
                         true,
+                        refreshPlaylist = false,
                     )
                     Log.i(
                         "StreamPlay",
                         "Startup sync succeeded: ${result.added} added, ${result.updated} updated"
                     )
+                    refreshNeeded = true
                 } catch (e: Exception) {
                     Log.e("StreamPlay", "Startup sync failed: ${e.message}")
+                }
+            }
+            if (refreshNeeded) {
+                val intent = Intent(this, StreamingService::class.java).apply {
+                    action = "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST"
+                }
+                try {
+                    startService(intent)
+                } catch (e: Exception) {
+                    Log.e("StreamPlay", "Failed to refresh playlist: ${e.message}")
                 }
             }
         }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,9 +1,9 @@
 package at.plankt0n.streamplay
 
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.util.Log
-import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
 import at.plankt0n.streamplay.helper.StationImportHelper
 import kotlinx.coroutines.runBlocking
@@ -12,7 +12,7 @@ class StreamPlayApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val prefs = getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
         if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
             val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
             Log.i("JSONAUTOSYNC", "Syncing personal JSON at startup")

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,28 +1,11 @@
 package at.plankt0n.streamplay
 
 import android.app.Application
-import android.util.Log
-import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
-import at.plankt0n.streamplay.helper.StationImportHelper
-import kotlinx.coroutines.runBlocking
 
 class StreamPlayApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
-            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
-            Log.i("StreamPlay", "Syncing personal JSON at startup")
-            runBlocking {
-                try {
-                    StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
-                } catch (e: Exception) {
-                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
-                }
-            }
-        }
 
         Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this))
     }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -15,7 +15,7 @@ class StreamPlayApplication : Application() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
             val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
-            Log.i("StreamPlay", "Syncing personal JSON at startup")
+            Log.i("JSONAUTOSYNC", "Syncing personal JSON at startup")
             var refreshNeeded = false
             runBlocking {
                 try {
@@ -26,12 +26,12 @@ class StreamPlayApplication : Application() {
                         refreshPlaylist = false,
                     )
                     Log.i(
-                        "StreamPlay",
+                        "JSONAUTOSYNC",
                         "Startup sync succeeded: ${result.added} added, ${result.updated} updated"
                     )
                     refreshNeeded = true
                 } catch (e: Exception) {
-                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
+                    Log.e("JSONAUTOSYNC", "Startup sync failed: ${e.message}")
                 }
             }
             if (refreshNeeded) {
@@ -41,7 +41,7 @@ class StreamPlayApplication : Application() {
                 try {
                     startService(intent)
                 } catch (e: Exception) {
-                    Log.e("StreamPlay", "Failed to refresh playlist: ${e.message}")
+                    Log.e("JSONAUTOSYNC", "Failed to refresh playlist: ${e.message}")
                 }
             }
         }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
 import at.plankt0n.streamplay.helper.StationImportHelper
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 class StreamPlayApplication : Application() {
@@ -15,9 +16,13 @@ class StreamPlayApplication : Application() {
         if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
             val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
             Log.i("StreamPlay", "Syncing personal JSON at startup")
-            runBlocking {
+            runBlocking(Dispatchers.IO) {
                 try {
-                    StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
+                    val result = StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
+                    Log.i(
+                        "StreamPlay",
+                        "Startup sync succeeded: ${result.added} added, ${result.updated} updated"
+                    )
                 } catch (e: Exception) {
                     Log.e("StreamPlay", "Startup sync failed: ${e.message}")
                 }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,11 +1,28 @@
 package at.plankt0n.streamplay
 
 import android.app.Application
+import android.util.Log
+import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
+import at.plankt0n.streamplay.helper.StationImportHelper
+import kotlinx.coroutines.runBlocking
 
 class StreamPlayApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
+            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
+            Log.i("StreamPlay", "Syncing personal JSON at startup")
+            runBlocking {
+                try {
+                    StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
+                } catch (e: Exception) {
+                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
+                }
+            }
+        }
 
         Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this))
     }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -1,11 +1,29 @@
 package at.plankt0n.streamplay
 
 import android.app.Application
+import android.util.Log
+import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
+import at.plankt0n.streamplay.helper.StationImportHelper
+import kotlinx.coroutines.runBlocking
 
 class StreamPlayApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
+            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
+            Log.i("StreamPlay", "Syncing personal JSON at startup")
+            runBlocking {
+                try {
+                    StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
+                } catch (e: Exception) {
+                    Log.e("StreamPlay", "Startup sync failed: ${e.message}")
+                }
+            }
+        }
+
         Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this))
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -21,7 +21,6 @@ class StreamPlayApplication : Application() {
                         this@StreamPlayApplication,
                         url,
                         true,
-                        refreshPlaylist = false,
                     )
                     Log.i(
                         "StreamPlay",

--- a/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamPlayApplication.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import at.plankt0n.streamplay.helper.CrashHandler
 import at.plankt0n.streamplay.helper.StationImportHelper
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 class StreamPlayApplication : Application() {
@@ -16,9 +15,14 @@ class StreamPlayApplication : Application() {
         if (prefs.getBoolean(Keys.PREF_PERSONAL_SYNC_STARTUP, false)) {
             val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, Keys.DEFAULT_PERSONAL_SYNC_URL) ?: ""
             Log.i("StreamPlay", "Syncing personal JSON at startup")
-            runBlocking(Dispatchers.IO) {
+            runBlocking {
                 try {
-                    val result = StationImportHelper.importStationsFromUrl(this@StreamPlayApplication, url, true)
+                    val result = StationImportHelper.importStationsFromUrl(
+                        this@StreamPlayApplication,
+                        url,
+                        true,
+                        refreshPlaylist = false,
+                    )
                     Log.i(
                         "StreamPlay",
                         "Startup sync succeeded: ${result.added} added, ${result.updated} updated"

--- a/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
@@ -30,7 +30,8 @@ object StationImportHelper {
     fun importStationsFromJson(
         context: Context,
         json: String,
-        replaceAll: Boolean
+        replaceAll: Boolean,
+        refreshPlaylist: Boolean = true,
     ): ImportResult {
         val type = object : TypeToken<List<ImportStation>>() {}.type
         val importedList: List<ImportStation> = Gson().fromJson(json, type)
@@ -69,10 +70,16 @@ object StationImportHelper {
 
         PreferencesHelper.saveStations(context, stationList)
         StateHelper.isPlaylistChangePending = true
-        val intent = Intent(context, StreamingService::class.java).apply {
-            action = "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST"
+        if (refreshPlaylist) {
+            val intent = Intent(context, StreamingService::class.java).apply {
+                action = "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST"
+            }
+            try {
+                context.startService(intent)
+            } catch (e: Exception) {
+                android.util.Log.e("StreamPlay", "Failed to refresh playlist: ${e.message}")
+            }
         }
-        context.startService(intent)
 
         return ImportResult(added, updated, stationList)
     }
@@ -80,7 +87,8 @@ object StationImportHelper {
     suspend fun importStationsFromUrl(
         context: Context,
         url: String,
-        replaceAll: Boolean
+        replaceAll: Boolean,
+        refreshPlaylist: Boolean = true,
     ): ImportResult {
         val normalizedUrl = if (url.contains("github.com") && url.contains("/blob/")) {
             url.replace("github.com/", "raw.githubusercontent.com/")
@@ -92,7 +100,7 @@ object StationImportHelper {
         val json = withContext(Dispatchers.IO) {
             URL(normalizedUrl).openStream().bufferedReader().use { it.readText() }
         }
-        return importStationsFromJson(context, json, replaceAll)
+        return importStationsFromJson(context, json, replaceAll, refreshPlaylist)
     }
 }
 

--- a/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
@@ -77,7 +77,7 @@ object StationImportHelper {
             try {
                 context.startService(intent)
             } catch (e: Exception) {
-                android.util.Log.e("StreamPlay", "Failed to refresh playlist: ${e.message}")
+                android.util.Log.e("JSONAUTOSYNC", "Failed to refresh playlist: ${e.message}")
             }
         }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -276,6 +276,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
+    val personalSyncAtStartupPref = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_PERSONAL_SYNC_STARTUP
+        title = getString(R.string.settings_sync_at_startup)
+        setDefaultValue(false)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
     val personalSyncPref = Preference(context).apply {
         key = "personal_sync_now"
         title = getString(R.string.settings_sync_personal_json)
@@ -391,6 +399,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         spotifySecretKeyPref,
         useSpotifyMetaPref,
         personalUrlPref,
+        personalSyncAtStartupPref,
         personalSyncPref,
         personalExportPref,
         versionPref,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="settings_personal_sync_url">Personal JSON URL</string>
     <string name="settings_personal_sync_url_empty">EMPTY</string>
     <string name="settings_sync_personal_json">Sync Personal JSON</string>
+    <string name="settings_sync_at_startup">Sync at Startup</string>
     <string name="settings_export_personal_json">Export Personal JSON</string>
     <string name="settings_add_test_stations">Add Test Stations</string>
     <string name="update_checking">Checking for updates…</string>


### PR DESCRIPTION
## Summary
- add `Sync at Startup` toggle under personal JSON settings
- when enabled, sync personal JSON before app startup and log entry

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4604d6c80832f84a9c9dcff19f0eb