### PR TITLE
Add screen orientation modes setting

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -20,6 +20,7 @@ object Keys {
 
     const val PREF_AUDIO_FOCUS_MODE = "audio_focus_mode"
     const val PREF_COVER_ANIMATION_STYLE = "cover_animation_style"
+    const val PREF_SCREEN_ORIENTATION = "screen_orientation"
 
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -2,6 +2,8 @@ package at.plankt0n.streamplay
 
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -15,19 +17,25 @@ import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.StateHelper
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.Keys
+import at.plankt0n.streamplay.ScreenOrientationMode
 import at.plankt0n.streamplay.ui.MainPagerFragment
 import at.plankt0n.streamplay.helper.StationImportHelper
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
 
     private var mainPagerFragment: MainPagerFragment? = null
     private var shortcutController: MediaServiceController? = null
     private var pendingShortcutStation: StationItem? = null
+    private lateinit var prefs: SharedPreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        prefs = getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.registerOnSharedPreferenceChangeListener(this)
+        applyOrientationPreference()
 
         setContentView(R.layout.activity_main)
 
@@ -49,6 +57,11 @@ class MainActivity : AppCompatActivity() {
 
         supportFragmentManager.executePendingTransactions()
         handleShortcutIntent(intent)
+    }
+
+    override fun onDestroy() {
+        prefs.unregisterOnSharedPreferenceChangeListener(this)
+        super.onDestroy()
     }
 
     private fun autoSyncIfEnabled() {
@@ -76,6 +89,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         maybePlayPendingShortcutStation()
+        applyOrientationPreference()
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -150,5 +164,22 @@ class MainActivity : AppCompatActivity() {
 
     fun showStationsPage() {
         mainPagerFragment?.showStations()
+    }
+
+    private fun applyOrientationPreference() {
+        val mode = ScreenOrientationMode.fromName(
+            prefs.getString(Keys.PREF_SCREEN_ORIENTATION, ScreenOrientationMode.AUTO.name)
+        )
+        requestedOrientation = when (mode) {
+            ScreenOrientationMode.LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            ScreenOrientationMode.PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            ScreenOrientationMode.AUTO -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key == Keys.PREF_SCREEN_ORIENTATION) {
+            applyOrientationPreference()
+        }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ScreenOrientationMode.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ScreenOrientationMode.kt
@@ -1,0 +1,12 @@
+package at.plankt0n.streamplay
+
+enum class ScreenOrientationMode {
+    AUTO,
+    LANDSCAPE,
+    PORTRAIT;
+
+    companion object {
+        fun fromName(name: String?): ScreenOrientationMode =
+            values().firstOrNull { it.name == name } ?: AUTO
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -11,8 +11,9 @@ import androidx.preference.*
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.AudioFocusMode
-import at.plankt0n.streamplay.data.CoverMode
+import at.plankt0n.streamplay.ScreenOrientationMode
 import at.plankt0n.streamplay.data.CoverAnimationStyle
+import at.plankt0n.streamplay.data.CoverMode
 import at.plankt0n.streamplay.helper.LiveCoverHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.StationImportHelper
@@ -129,6 +130,24 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         showSeekBarValue = true
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_timer)
+    }
+
+    val orientationPref = ListPreference(context).apply {
+        key = Keys.PREF_SCREEN_ORIENTATION
+        title = getString(R.string.settings_rotation)
+        entries = arrayOf(
+            getString(R.string.orientation_auto),
+            getString(R.string.orientation_landscape),
+            getString(R.string.orientation_portrait)
+        )
+        entryValues = arrayOf(
+            ScreenOrientationMode.AUTO.name,
+            ScreenOrientationMode.LANDSCAPE.name,
+            ScreenOrientationMode.PORTRAIT.name
+        )
+        setDefaultValue(ScreenOrientationMode.AUTO.name)
+        category = SettingsCategory.UI
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
     val bannerSwitch = SwitchPreferenceCompat(context).apply {
@@ -391,6 +410,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         autoplaySwitch,
         minimizeSwitch,
         delayPreference,
+        orientationPref,
         bannerSwitch,
         backgroundEffectPref,
         coverModePref,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,10 @@
     <string name="settings_delay">Minimize Delay</string>
     <string name="settings_delay_seconds">%1$d s</string>
     <string name="settings_minimize">Minimize after Autoplay</string>
+    <string name="settings_rotation">Screen Orientation</string>
+    <string name="orientation_auto">Auto rotate</string>
+    <string name="orientation_landscape">Lock landscape</string>
+    <string name="orientation_portrait">Lock portrait</string>
     <string name="settings_category_playback">Playback</string>
     <string name="settings_category_ui">UI Settings</string>
     <string name="settings_category_metainfo">Metainfo Settings</string>


### PR DESCRIPTION
## Summary
- let users pick between auto rotation, locked landscape, or locked portrait
- persist orientation choice and apply it in MainActivity via new enum

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0d5c89ac832f8095774dff58c457