### PR TITLE
Show selected settings and lock orientation in bottom sheet

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/BottomSheet.kt
@@ -1,5 +1,7 @@
 package at.plankt0n.streamplay.ui
 
+import android.content.DialogInterface
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -18,6 +20,8 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
     companion object {
         const val TAG = "MediaItemOptionsBottomSheet"
     }
+
+    private var previousOrientation: Int? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -58,6 +62,8 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
 
     override fun onStart() {
         super.onStart()
+        previousOrientation = activity?.requestedOrientation
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
         val dialog = dialog as? com.google.android.material.bottomsheet.BottomSheetDialog
         val bottomSheet = dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
@@ -66,6 +72,11 @@ class MediaItemOptionsBottomSheet : BottomSheetDialogFragment() {
             behavior.state = com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
             it.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        previousOrientation?.let { activity?.requestedOrientation = it }
+        super.onDismiss(dialog)
     }
 
     private fun openStationsFragment() {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -112,6 +112,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setDefaultValue(AudioFocusMode.STOP.name)
         category = SettingsCategory.PLAYER
         icon = context.getDrawable(R.drawable.ic_button_play)
+        summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
     }
 
     val minimizeSwitch = SwitchPreferenceCompat(context).apply {
@@ -148,6 +149,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setDefaultValue(ScreenOrientationMode.AUTO.name)
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
     }
 
     val bannerSwitch = SwitchPreferenceCompat(context).apply {
@@ -200,6 +202,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setDefaultValue(CoverMode.META.name)
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
     }
 
     val coverAnimationStylePref = ListPreference(context).apply {
@@ -218,6 +221,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setDefaultValue(CoverAnimationStyle.FLIP.name)
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
     }
 
     val spotifyApiKeyPref = EditTextPreference(context).apply {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -186,6 +186,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setDefaultValue(LiveCoverHelper.BackgroundEffect.FADE.name)
         category = SettingsCategory.UI
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
     }
 
     val coverModePref = ListPreference(context).apply {


### PR DESCRIPTION
## Summary
- Display current selections for audio focus, rotation, cover source, and cover animation settings
- Prevent rotation while the bottom sheet menu is open and restore orientation afterward

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1caeb3a8832fbd9a8fe72484084e