### PR TITLE
Add first-launch onboarding flow

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -25,6 +25,7 @@ object Keys {
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"
     const val PREF_AUTOSYNC_JSON_STARTUP = "autosync_json_startup"
+    const val PREF_ONBOARDING_DONE = "onboarding_done"
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -1,5 +1,6 @@
 package at.plankt0n.streamplay
 
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -19,6 +20,7 @@ import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.ScreenOrientationMode
 import at.plankt0n.streamplay.ui.MainPagerFragment
+import at.plankt0n.streamplay.ui.DiscoverFragment
 import at.plankt0n.streamplay.helper.StationImportHelper
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -57,6 +59,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
         supportFragmentManager.executePendingTransactions()
         handleShortcutIntent(intent)
+        maybeShowOnboarding()
     }
 
     override fun onDestroy() {
@@ -164,6 +167,41 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
     fun showStationsPage() {
         mainPagerFragment?.showStations()
+    }
+
+    private fun openDiscoverPage() {
+        supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .replace(R.id.fragment_container, DiscoverFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    private fun maybeShowOnboarding() {
+        if (!prefs.getBoolean(Keys.PREF_ONBOARDING_DONE, false)) {
+            AlertDialog.Builder(this)
+                .setTitle("Setup Assistance")
+                .setMessage("Would you like help with setup? You can improve metadata using the Spotify API (images and info).")
+                .setPositiveButton(android.R.string.yes) { _, _ ->
+                    AlertDialog.Builder(this)
+                        .setTitle("Add Stations")
+                        .setMessage("Would you like to add stations now?")
+                        .setPositiveButton(android.R.string.yes) { _, _ ->
+                            openDiscoverPage()
+                            prefs.edit().putBoolean(Keys.PREF_ONBOARDING_DONE, true).apply()
+                        }
+                        .setNegativeButton(android.R.string.no) { _, _ ->
+                            prefs.edit().putBoolean(Keys.PREF_ONBOARDING_DONE, true).apply()
+                        }
+                        .setCancelable(false)
+                        .show()
+                }
+                .setNegativeButton(android.R.string.no) { _, _ ->
+                    prefs.edit().putBoolean(Keys.PREF_ONBOARDING_DONE, true).apply()
+                }
+                .setCancelable(false)
+                .show()
+        }
     }
 
     private fun applyOrientationPreference() {


### PR DESCRIPTION
## Summary
- add preference flag to track completion of initial setup
- show initial setup assistance with option to add stations via Discover screen
- highlight Spotify API metadata improvement during onboarding

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3834ee84832f97f4ead983fede88