### PR TITLE
feat: add global svg image support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     id("kotlin-parcelize")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -71,11 +72,13 @@ dependencies {
         implementation("androidx.work:work-runtime-ktx:2.9.0")
 
         // Gson
-        implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.google.code.gson:gson:2.10.1")
     //Glide
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.caverock:androidsvg:1.4")
+    kapt("com.github.bumptech.glide:compiler:4.16.0")
 
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/DiscoverAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/DiscoverAdapter.kt
@@ -8,7 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
-import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.loadUrl
 
 class DiscoverAdapter(
     private val items: List<StationItem>,
@@ -31,11 +31,11 @@ class DiscoverAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
         holder.text.text = item.stationName
-        Glide.with(holder.image.context)
-            .load(item.iconURL)
-            .placeholder(R.drawable.ic_placeholder_logo)
-            .error(R.drawable.ic_stationcover_placeholder)
-            .into(holder.image)
+        holder.image.loadUrl(
+            item.iconURL,
+            placeholder = R.drawable.ic_placeholder_logo,
+            error = R.drawable.ic_stationcover_placeholder
+        )
         holder.itemView.setOnClickListener { onClick(item) }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/SearchResultAdapter.kt
@@ -9,7 +9,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
-import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.loadUrl
 
 class SearchResultAdapter(
     private val searchResults: List<StationItem>,
@@ -35,10 +35,10 @@ class SearchResultAdapter(
         holder.textStationName.text = result.stationName
         holder.textStreamUrl.text = result.streamURL
 
-        Glide.with(holder.imageLogo.context)
-            .load(result.iconURL)
-            .placeholder(R.drawable.ic_stationcover_placeholder)
-            .into(holder.imageLogo)
+        holder.imageLogo.loadUrl(
+            result.iconURL,
+            placeholder = R.drawable.ic_stationcover_placeholder
+        )
 
         holder.itemView.setOnClickListener {
             onClick(result)

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/ShortcutAdapter.kt
@@ -8,7 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.ShortcutItem
-import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.loadUrl
 
 class ShortcutAdapter(
     private val onClick: (ShortcutItem) -> Unit
@@ -39,12 +39,11 @@ class ShortcutAdapter(
         val item = items[position]
         holder.labelTextView.text = item.label
         val source = item.iconUrl.takeIf { it.isNotBlank() }
-        Glide.with(holder.itemView)
-            .load(source)
-            .placeholder(R.drawable.ic_placeholder_logo)
-            .error(R.drawable.ic_radio)
-            .fallback(R.drawable.ic_radio)
-            .into(holder.iconImageView)
+        holder.iconImageView.loadUrl(
+            source ?: "",
+            placeholder = R.drawable.ic_placeholder_logo,
+            error = R.drawable.ic_radio
+        )
 
         holder.itemView.setOnClickListener { onClick(item) }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/StationListAdapter.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
-import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.loadUrl
 import androidx.recyclerview.widget.RecyclerView
 import at.plankt0n.streamplay.R
 import at.plankt0n.streamplay.data.StationItem
@@ -71,12 +71,11 @@ class StationListAdapter(
             true
         }
 
-        Glide.with(holder.playButton.context)
-            .load(station.iconURL)
-            .placeholder(R.drawable.ic_stationcover_placeholder)
-            .error(R.drawable.ic_stationcover_placeholder)
-            .fallback(R.drawable.ic_stationcover_placeholder)
-            .into(holder.playButton)
+        holder.playButton.loadUrl(
+            station.iconURL,
+            placeholder = R.drawable.ic_stationcover_placeholder,
+            error = R.drawable.ic_stationcover_placeholder
+        )
 
         val context = holder.itemView.context
         if (position == currentPlayingIndex) {

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgDecoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgDecoder.kt
@@ -1,0 +1,29 @@
+package at.plankt0n.streamplay.glide
+
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.SVGParseException
+import java.io.InputStream
+
+/**
+ * Decodes an [InputStream] into an [SVG] instance for Glide.
+ */
+class SvgDecoder : ResourceDecoder<InputStream, SVG> {
+    override fun handles(source: InputStream, options: Options): Boolean = true
+
+    override fun decode(
+        source: InputStream,
+        width: Int,
+        height: Int,
+        options: Options
+    ): Resource<SVG>? = try {
+        val svg = SVG.getFromInputStream(source)
+        SimpleResource(svg)
+    } catch (ex: SVGParseException) {
+        null
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgDrawableTranscoder.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgDrawableTranscoder.kt
@@ -1,0 +1,24 @@
+package at.plankt0n.streamplay.glide
+
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.SVG
+
+/**
+ * Converts [SVG] objects into [PictureDrawable] for display in an [ImageView].
+ */
+class SvgDrawableTranscoder : ResourceTranscoder<SVG, PictureDrawable> {
+    override fun transcode(
+        toTranscode: Resource<SVG>,
+        options: Options
+    ): Resource<PictureDrawable> {
+        val svg = toTranscode.get()
+        val picture = svg.renderToPicture()
+        val drawable = PictureDrawable(picture)
+        return SimpleResource(drawable)
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgModule.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgModule.kt
@@ -1,0 +1,22 @@
+package at.plankt0n.streamplay.glide
+
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+import com.caverock.androidsvg.SVG
+import java.io.InputStream
+import android.graphics.drawable.PictureDrawable
+
+/**
+ * Registers SVG loading components with Glide.
+ */
+@GlideModule
+class SvgModule : AppGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry.register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder())
+            .append(InputStream::class.java, SVG::class.java, SvgDecoder())
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/glide/SvgSoftwareLayerSetter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/glide/SvgSoftwareLayerSetter.kt
@@ -1,0 +1,42 @@
+package at.plankt0n.streamplay.glide
+
+import android.graphics.drawable.PictureDrawable
+import android.view.View
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.ImageViewTarget
+import com.bumptech.glide.request.target.Target
+
+/**
+ * Ensures that SVGs are rendered using software layer to avoid issues with hardware acceleration.
+ */
+class SvgSoftwareLayerSetter : RequestListener<PictureDrawable> {
+    override fun onLoadFailed(
+        e: GlideException?,
+        model: Any?,
+        target: Target<PictureDrawable>?,
+        isFirstResource: Boolean
+    ): Boolean {
+        if (target is ImageViewTarget<*>) {
+            val view = target.view
+            view.setLayerType(View.LAYER_TYPE_NONE, null)
+        }
+        return false
+    }
+
+    override fun onResourceReady(
+        resource: PictureDrawable?,
+        model: Any?,
+        target: Target<PictureDrawable>?,
+        dataSource: DataSource?,
+        isFirstResource: Boolean
+    ): Boolean {
+        if (target is ImageViewTarget<*>) {
+            val view = target.view
+            view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+        }
+        return false
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/helper/ImageLoader.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/ImageLoader.kt
@@ -1,0 +1,71 @@
+package at.plankt0n.streamplay.helper
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.BitmapImageViewTarget
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
+import at.plankt0n.streamplay.glide.SvgSoftwareLayerSetter
+
+/**
+ * Loads images into an [ImageView] and transparently handles SVG sources.
+ * Optionally returns the loaded [Bitmap] via [onBitmapReady].
+ */
+fun ImageView.loadUrl(
+    url: String,
+    placeholder: Int? = null,
+    error: Int? = null,
+    onBitmapReady: ((Bitmap?) -> Unit)? = null
+) {
+    if (url.lowercase().endsWith(".svg")) {
+        val builder = Glide.with(this)
+            .`as`(PictureDrawable::class.java)
+            .listener(SvgSoftwareLayerSetter())
+            .load(url)
+
+        placeholder?.let { builder.placeholder(it) }
+        error?.let { builder.error(it) }
+
+        builder.into(object : CustomTarget<PictureDrawable>() {
+            override fun onResourceReady(
+                resource: PictureDrawable,
+                transition: Transition<in PictureDrawable>?
+            ) {
+                this@loadUrl.setImageDrawable(resource)
+                onBitmapReady?.invoke(resource.toBitmap())
+            }
+
+            override fun onLoadCleared(placeholder: Drawable?) {
+                this@loadUrl.setImageDrawable(placeholder)
+            }
+        })
+    } else {
+        val builder = Glide.with(this)
+            .asBitmap()
+            .load(url)
+
+        placeholder?.let { builder.placeholder(it) }
+        error?.let { builder.error(it) }
+
+        builder.into(object : BitmapImageViewTarget(this) {
+            override fun setResource(resource: Bitmap?) {
+                super.setResource(resource)
+                onBitmapReady?.invoke(resource)
+            }
+        })
+    }
+}
+
+/** Converts a [PictureDrawable] to a [Bitmap]. */
+fun PictureDrawable.toBitmap(): Bitmap {
+    val picture = this.picture
+    val bitmap = Bitmap.createBitmap(picture.width, picture.height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    canvas.drawPicture(picture)
+    return bitmap
+}
+

--- a/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/LiveCoverHelper.kt
@@ -11,7 +11,6 @@ import android.widget.ImageView
 import at.plankt0n.streamplay.R
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.BitmapImageViewTarget
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import androidx.palette.graphics.Palette
@@ -42,81 +41,76 @@ object LiveCoverHelper {
         onNewColor: (Int) -> Unit,
         onNewEffect: (BackgroundEffect) -> Unit
     ) {
-        Glide.with(context)
-            .asBitmap()
-            .load(imageUrl)
-            .placeholder(R.drawable.ic_placeholder_logo)
-            .error(R.drawable.ic_stationcover_placeholder)
-            .into(object : BitmapImageViewTarget(imageView) {
-                override fun setResource(resource: Bitmap?) {
-                    super.setResource(resource)
-                    resource?.let { bitmap ->
-                        if (effect == BackgroundEffect.BLUR) {
-                            Palette.from(bitmap).generate { palette ->
-                                val dominantColor = palette?.getDominantColor(defaultColor) ?: defaultColor
+        imageView.loadUrl(
+            imageUrl,
+            placeholder = R.drawable.ic_placeholder_logo,
+            error = R.drawable.ic_stationcover_placeholder
+        ) { bitmap ->
+            bitmap?.let { bmp ->
+                if (effect == BackgroundEffect.BLUR) {
+                    Palette.from(bmp).generate { palette ->
+                        val dominantColor = palette?.getDominantColor(defaultColor) ?: defaultColor
 
-                                val hsv = FloatArray(3)
-                                Color.colorToHSV(dominantColor, hsv)
-                                hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
-                                hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
-                                val smoothColor = Color.HSVToColor(hsv)
+                        val hsv = FloatArray(3)
+                        Color.colorToHSV(dominantColor, hsv)
+                        hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
+                        hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
+                        val smoothColor = Color.HSVToColor(hsv)
 
-                                Glide.with(context)
-                                    .asBitmap()
-                                    .load(imageUrl)
-                                    .apply(
-                                        RequestOptions()
-                                            .centerCrop()
-                                            .transform(BlurTransformation(25, 3))
-                                    )
-                                    .into(object : CustomTarget<Bitmap>() {
-                                        override fun onResourceReady(
-                                            resource: Bitmap,
-                                            transition: Transition<in Bitmap>?,
-                                        ) {
-                                            backgroundTarget.background =
-                                                BitmapDrawable(context.resources, resource)
-                                            onNewColor(smoothColor)
-                                            onNewEffect(effect)
-                                        }
-
-                                        override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
-                                    })
-                            }
-                        } else {
-                            Palette.from(bitmap).generate { palette ->
-                                palette?.let {
-                                    val dominantColor = it.getDominantColor(defaultColor)
-
-                                    val hsv = FloatArray(3)
-                                    Color.colorToHSV(dominantColor, hsv)
-                                    hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
-                                    hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
-                                    val smoothColor = Color.HSVToColor(hsv)
-
-                                    // Nur animieren, wenn sich Farbe oder Effekt ändert
-                                    if (lastColor != smoothColor || lastEffect != effect) {
-                                        val animator = ValueAnimator.ofArgb(
-                                            lastColor ?: defaultColor,
-                                            smoothColor
-                                        ).apply {
-                                            duration = 400
-                                            addUpdateListener { anim ->
-                                                val color = anim.animatedValue as Int
-                                                val gradient = createGradient(color, effect)
-                                                backgroundTarget.background = gradient
-                                            }
-                                        }
-                                        animator.start()
-                                    }
+                        Glide.with(context)
+                            .asBitmap()
+                            .load(bmp)
+                            .apply(
+                                RequestOptions()
+                                    .centerCrop()
+                                    .transform(BlurTransformation(25, 3))
+                            )
+                            .into(object : CustomTarget<Bitmap>() {
+                                override fun onResourceReady(
+                                    resource: Bitmap,
+                                    transition: Transition<in Bitmap>?
+                                ) {
+                                    backgroundTarget.background = BitmapDrawable(context.resources, resource)
                                     onNewColor(smoothColor)
                                     onNewEffect(effect)
                                 }
+
+                                override fun onLoadCleared(placeholder: android.graphics.drawable.Drawable?) {}
+                            })
+                    }
+                } else {
+                    Palette.from(bmp).generate { palette ->
+                        palette?.let {
+                            val dominantColor = it.getDominantColor(defaultColor)
+
+                            val hsv = FloatArray(3)
+                            Color.colorToHSV(dominantColor, hsv)
+                            hsv[1] = (hsv[1] * 0.7f).coerceAtMost(1.0f)
+                            hsv[2] = (hsv[2] + 0.1f).coerceAtMost(1.0f)
+                            val smoothColor = Color.HSVToColor(hsv)
+
+                            // Nur animieren, wenn sich Farbe oder Effekt ändert
+                            if (lastColor != smoothColor || lastEffect != effect) {
+                                val animator = ValueAnimator.ofArgb(
+                                    lastColor ?: defaultColor,
+                                    smoothColor
+                                ).apply {
+                                    duration = 400
+                                    addUpdateListener { anim ->
+                                        val color = anim.animatedValue as Int
+                                        val gradient = createGradient(color, effect)
+                                        backgroundTarget.background = gradient
+                                    }
+                                }
+                                animator.start()
                             }
+                            onNewColor(smoothColor)
+                            onNewEffect(effect)
                         }
                     }
                 }
-            })
+            }
+        }
     }
 
     fun createGradient(color: Int, effect: BackgroundEffect): GradientDrawable {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -48,6 +48,7 @@ import at.plankt0n.streamplay.Keys
 import androidx.core.graphics.ColorUtils
 import androidx.media3.common.Player
 import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.loadUrl
 import com.google.android.material.imageview.ShapeableImageView
 import com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
 import android.widget.Toast
@@ -273,9 +274,16 @@ class PlayerFragment : Fragment() {
                 adjustDotsIndicatorScale()
 
                 coverPageAdapter.mediaItems.forEach { item ->
-                    Glide.with(requireContext())
-                        .load(item.iconURL)
-                        .preload()
+                    if (item.iconURL.lowercase().endsWith(".svg")) {
+                        Glide.with(requireContext())
+                            .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                            .load(item.iconURL)
+                            .preload()
+                    } else {
+                        Glide.with(requireContext())
+                            .load(item.iconURL)
+                            .preload()
+                    }
                 }
 
                 val currentIndex = controller.currentMediaItemIndex
@@ -417,11 +425,7 @@ class PlayerFragment : Fragment() {
                 metaFlipper.stopFlipping()
                 metaFlipper.displayedChild = 0
 
-                Glide.with(requireContext())
-                    .load(R.drawable.placeholder_spotify_dark)
-                    .placeholder(R.drawable.placeholder_spotify_dark)
-                    .error(R.drawable.placeholder_spotify_dark)
-                    .into(stationIconView!!)
+                stationIconView?.setImageResource(R.drawable.placeholder_spotify_dark)
 
                 return@observe
             }
@@ -556,17 +560,17 @@ class PlayerFragment : Fragment() {
             }
 
             if (coverMode == CoverMode.META && !trackInfo.bestCoverUrl.isNullOrBlank()) {
-                Glide.with(requireContext())
-                    .load(trackInfo.bestCoverUrl)
-                    .placeholder(R.drawable.ic_placeholder_logo)
-                    .error(R.drawable.ic_stationcover_placeholder)
-                    .into(stationIconView!!)
+                stationIconView?.loadUrl(
+                    trackInfo.bestCoverUrl,
+                    placeholder = R.drawable.ic_placeholder_logo,
+                    error = R.drawable.ic_stationcover_placeholder
+                )
             } else {
-                Glide.with(requireContext())
-                    .load(defaultIconUrl)
-                    .placeholder(R.drawable.ic_placeholder_logo)
-                    .error(R.drawable.ic_stationcover_placeholder)
-                    .into(stationIconView!!)
+                stationIconView?.loadUrl(
+                    defaultIconUrl,
+                    placeholder = R.drawable.ic_placeholder_logo,
+                    error = R.drawable.ic_stationcover_placeholder
+                )
             }
 
             enableMarquee(titleTextView!!, artistTextView!!, genreTextView!!, albumTextView!!)
@@ -604,11 +608,11 @@ class PlayerFragment : Fragment() {
         val iconUrl = extras.getString("EXTRA_ICON_URL") ?: ""
 
         stationNameTextView.text = stationName
-        Glide.with(stationIconImageView)
-            .load(iconUrl)
-            .placeholder(R.drawable.placeholder_spotify_dark)
-            .error(R.drawable.placeholder_spotify_dark)
-            .into(stationIconImageView)
+        stationIconImageView.loadUrl(
+            iconUrl,
+            placeholder = R.drawable.placeholder_spotify_dark,
+            error = R.drawable.placeholder_spotify_dark
+        )
     }
 
     private fun updatePlayPauseIcon(isPlaying: Boolean) {
@@ -707,7 +711,14 @@ class PlayerFragment : Fragment() {
         adjustDotsIndicatorScale()
 
         coverPageAdapter.mediaItems.forEach { item ->
-            Glide.with(requireContext()).load(item.iconURL).preload()
+            if (item.iconURL.lowercase().endsWith(".svg")) {
+                Glide.with(requireContext())
+                    .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                    .load(item.iconURL)
+                    .preload()
+            } else {
+                Glide.with(requireContext()).load(item.iconURL).preload()
+            }
         }
 
         val currentIndex = mediaServiceController.getCurrentStreamIndex()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -37,6 +37,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import at.plankt0n.streamplay.Keys
 import com.bumptech.glide.Glide
+import at.plankt0n.streamplay.helper.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -259,7 +260,16 @@ class StationsFragment : Fragment() {
             val bitmap = withContext(Dispatchers.IO) {
                 try {
                     if (station.iconURL.isNotBlank()) {
-                        Glide.with(context).asBitmap().load(station.iconURL).submit().get()
+                        if (station.iconURL.lowercase().endsWith(".svg")) {
+                            val drawable = Glide.with(context)
+                                .`as`(android.graphics.drawable.PictureDrawable::class.java)
+                                .load(station.iconURL)
+                                .submit()
+                                .get()
+                            drawable.toBitmap()
+                        } else {
+                            Glide.with(context).asBitmap().load(station.iconURL).submit().get()
+                        }
                     } else {
                         null
                     }


### PR DESCRIPTION
## Summary
- add AndroidSVG and Glide compiler dependencies
- load SVG images using Glide module and helper
- update image calls to handle SVGs app-wide

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc404a28e4832fb94fd1b1c6591725