### PR TITLE
Avoid redundant cover reloads

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/adapter/CoverPageAdapter.kt
@@ -22,6 +22,7 @@ class CoverPageAdapter(
         val coverImage: ShapeableImageView = itemView.findViewById(R.id.cover_image)
         var lastColor: Int? = null
         var lastEffect: LiveCoverHelper.BackgroundEffect? = null
+        var lastImageUrl: String? = null
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CoverViewHolder {
@@ -45,6 +46,7 @@ class CoverPageAdapter(
             onNewColor = { holder.lastColor = it },
             onNewEffect = { holder.lastEffect = it }
         )
+        holder.lastImageUrl = item.iconURL
     }
 
     override fun getItemCount(): Int = mediaItems.size

--- a/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/PlayerFragment.kt
@@ -88,6 +88,7 @@ class PlayerFragment : Fragment() {
     private var backgroundEffect = LiveCoverHelper.BackgroundEffect.FADE
     private var coverMode = CoverMode.META
     private var coverAnimationStyle = CoverAnimationStyle.FLIP
+    private var lastImageUrl: String? = null
     private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { shared, key ->
         if (key == "show_exoplayer_banner") {
             showInfoBanner = shared.getBoolean(key, true)
@@ -440,48 +441,53 @@ class PlayerFragment : Fragment() {
                 CoverMode.STATION -> defaultIconUrl
             }
 
-            val loadCover = {
-                LiveCoverHelper.loadCoverWithBackground(
-                    context = requireContext(),
-                    imageUrl = imageUrlToLoad,
-                    imageView = holder.coverImage,
-                    backgroundTarget = holder.itemView,
-                    defaultColor = requireContext().getColor(R.color.default_background),
-                    lastColor = holder.lastColor,
-                    lastEffect = holder.lastEffect,
-                    effect = backgroundEffect,
-                    onNewColor = {
-                        holder.lastColor = it
-                        updateOverlayColors(it)
-                    },
-                    onNewEffect = { holder.lastEffect = it }
-                )
-            }
+            if (imageUrlToLoad != lastImageUrl) {
+                val loadCover = {
+                    LiveCoverHelper.loadCoverWithBackground(
+                        context = requireContext(),
+                        imageUrl = imageUrlToLoad,
+                        imageView = holder.coverImage,
+                        backgroundTarget = holder.itemView,
+                        defaultColor = requireContext().getColor(R.color.default_background),
+                        lastColor = holder.lastColor,
+                        lastEffect = holder.lastEffect,
+                        effect = backgroundEffect,
+                        onNewColor = {
+                            holder.lastColor = it
+                            updateOverlayColors(it)
+                        },
+                        onNewEffect = { holder.lastEffect = it }
+                    )
+                }
 
-            when (coverAnimationStyle) {
-                CoverAnimationStyle.FLIP -> {
-                    holder.coverImage.animate()
-                        .rotationY(90f)
-                        .setDuration(150)
-                        .withEndAction {
-                            loadCover()
-                            holder.coverImage.rotationY = -90f
-                            holder.coverImage.animate().rotationY(0f).setDuration(150).start()
-                        }
-                        .start()
+                when (coverAnimationStyle) {
+                    CoverAnimationStyle.FLIP -> {
+                        holder.coverImage.animate()
+                            .rotationY(90f)
+                            .setDuration(150)
+                            .withEndAction {
+                                loadCover()
+                                holder.coverImage.rotationY = -90f
+                                holder.coverImage.animate().rotationY(0f).setDuration(150).start()
+                            }
+                            .start()
+                    }
+                    CoverAnimationStyle.FADE -> {
+                        holder.coverImage.animate()
+                            .alpha(0f)
+                            .setDuration(150)
+                            .withEndAction {
+                                loadCover()
+                                holder.coverImage.alpha = 0f
+                                holder.coverImage.animate().alpha(1f).setDuration(150).start()
+                            }
+                            .start()
+                    }
+                    CoverAnimationStyle.NONE -> loadCover()
                 }
-                CoverAnimationStyle.FADE -> {
-                    holder.coverImage.animate()
-                        .alpha(0f)
-                        .setDuration(150)
-                        .withEndAction {
-                            loadCover()
-                            holder.coverImage.alpha = 0f
-                            holder.coverImage.animate().alpha(1f).setDuration(150).start()
-                        }
-                        .start()
-                }
-                CoverAnimationStyle.NONE -> loadCover()
+
+                holder.lastImageUrl = imageUrlToLoad
+                lastImageUrl = imageUrlToLoad
             }
 
             if (coverMode == CoverMode.META && metaCoverUrl != null) {


### PR DESCRIPTION
## Summary
- track the last loaded cover URL to avoid replaying animations for unchanged images
- optionally store the last loaded cover per page via `CoverViewHolder`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67443d9c832faa7a7026721c1800