### PR TITLE
Avoid redundant track info updates

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/viewmodel/UITrackInfo.kt
@@ -27,11 +27,17 @@ object UITrackRepository {
     private val _trackInfo = MutableLiveData<UITrackInfo?>()
     val trackInfo: LiveData<UITrackInfo?> get() = _trackInfo
 
+    private var lastTrackInfo: UITrackInfo? = null
+
     fun updateTrackInfo(info: UITrackInfo) {
-        _trackInfo.postValue(info)
+        if (lastTrackInfo != info) {
+            lastTrackInfo = info
+            _trackInfo.postValue(info)
+        }
     }
 
     fun clearTrackInfo() {
+        lastTrackInfo = null
         _trackInfo.postValue(null)
         Log.d("UITrackinfo", "Trackinfo cleared")
     }


### PR DESCRIPTION
## Summary
- Cache last `UITrackInfo` in `UITrackRepository` to avoid redundant updates
- Reset cached info when clearing track information

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69f7e06c832facbeaeb6b634582b