### PR TITLE
Set mediaId for media items and validate shortcut index lookup

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -146,14 +146,14 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         shortcutController = MediaServiceController(this)
         shortcutController?.initializeAndConnect(
             onConnected = {
-                val idx = shortcutController?.findIndexByMediaId(station.streamURL) ?: index
+                val idx = shortcutController?.findIndexByMediaId(station.streamURL)?.takeIf { it >= 0 } ?: index
                 shortcutController?.playAtIndex(idx)
             },
             onPlaybackChanged = {},
             onStreamIndexChanged = {},
             onMetadataChanged = {},
             onTimelineChanged = {
-                val idx = shortcutController?.findIndexByMediaId(station.streamURL) ?: index
+                val idx = shortcutController?.findIndexByMediaId(station.streamURL)?.takeIf { it >= 0 } ?: index
                 shortcutController?.playAtIndex(idx)
                 StateHelper.isPlaylistChangePending = false
             },

--- a/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/StreamingService.kt
@@ -334,8 +334,8 @@ class StreamingService : MediaSessionService() {
                 .build()
 
             MediaItem.Builder()
-
                 .setUri(it.streamURL)
+                .setMediaId(it.streamURL)
                 .setMediaMetadata(metadata)
                 .build()
         }
@@ -375,6 +375,7 @@ class StreamingService : MediaSessionService() {
 
             MediaItem.Builder()
                 .setUri(it.streamURL)
+                .setMediaId(it.streamURL)
                 .setMediaMetadata(metadata)
                 .build()
         }


### PR DESCRIPTION
## Summary
- Assign stream URL as `mediaId` for playlist items so controller lookups can match
- Guard `findIndexByMediaId` results and fall back to computed index when necessary

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d37ecac832f8f91022c99dee031