### PR TITLE
feat: add live resume option

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -21,6 +21,7 @@ object Keys {
     const val PREF_AUDIO_FOCUS_MODE = "audio_focus_mode"
     const val PREF_COVER_ANIMATION_STYLE = "cover_animation_style"
     const val PREF_SCREEN_ORIENTATION = "screen_orientation"
+    const val PREF_RESUME_LIVE_AFTER_PAUSE = "resume_live_after_pause"
 
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"

--- a/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/MediaServiceController.kt
@@ -15,6 +15,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import at.plankt0n.streamplay.StreamingService
+import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.data.StationItem
 import java.lang.Thread.State
 
@@ -173,6 +174,10 @@ class MediaServiceController(private val context: Context) {
         if (controller.isPlaying) {
             controller.pause()
         } else {
+            val prefs = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+            if (prefs.getBoolean(Keys.PREF_RESUME_LIVE_AFTER_PAUSE, false)) {
+                controller.seekToDefaultPosition(controller.currentMediaItemIndex)
+            }
             controller.play()
         }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -238,6 +238,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_autoplay)
     }
 
+    val resumeLiveSwitch = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_RESUME_LIVE_AFTER_PAUSE
+        title = getString(R.string.settings_resume_live_after_pause)
+        setDefaultValue(false)
+        category = SettingsCategory.PLAYER
+        icon = context.getDrawable(R.drawable.ic_button_play)
+    }
+
     val backgroundEffectPref = ListPreference(context).apply {
         key = "background_effect"
         title = getString(R.string.settings_background_effect)
@@ -519,6 +527,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         delayPreference,
         orientationPref,
         bannerSwitch,
+        resumeLiveSwitch,
         backgroundEffectPref,
         coverModePref,
         coverAnimationStylePref,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,5 @@
     <string name="settings_audiofocus_stop">Stop Playing</string>
     <string name="settings_audiofocus_hold">Hold Audiofocus</string>
     <string name="settings_audiofocus_lower">Lower Audio</string>
+    <string name="settings_resume_live_after_pause">Resume Live After Pause</string>
 </resources>


### PR DESCRIPTION
## Summary
- add player setting to resume live after pause
- allow controller to jump to live position when resuming

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1e5c7060832f8296b4d46ed9199a