### PR TITLE
Add JSONBin synchronization option

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -25,6 +25,9 @@ object Keys {
 
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"
+    const val PREF_USE_JSONBIN = "use_jsonbin"
+    const val PREF_JSONBIN_URL = "jsonbin_url"
+    const val PREF_JSONBIN_MASTER_KEY = "jsonbin_master_key"
     const val PREF_AUTOSYNC_JSON_STARTUP = "autosync_json_startup"
     const val PREF_ONBOARDING_DONE = "onboarding_done"
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -70,19 +70,38 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     private fun autoSyncIfEnabled() {
         val prefs = getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
         if (prefs.getBoolean(Keys.PREF_AUTOSYNC_JSON_STARTUP, false)) {
-            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, "") ?: ""
-            if (url.isNotBlank()) {
-                Log.d("JSON AUTO SYNC>", "Starting auto sync")
-                runBlocking {
-                    try {
-                        StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
-                        Log.d("JSON AUTO SYNC>", "Auto sync completed")
-                    } catch (e: Exception) {
-                        Log.e("JSON AUTO SYNC>", "Auto sync failed: ${e.message}")
+            val useJsonBin = prefs.getBoolean(Keys.PREF_USE_JSONBIN, false)
+            if (useJsonBin) {
+                val binUrl = prefs.getString(Keys.PREF_JSONBIN_URL, "") ?: ""
+                val key = prefs.getString(Keys.PREF_JSONBIN_MASTER_KEY, "") ?: ""
+                if (binUrl.isNotBlank() && key.isNotBlank()) {
+                    Log.d("JSON AUTO SYNC>", "Starting auto sync (JSONBin)")
+                    runBlocking {
+                        try {
+                            StationImportHelper.importStationsFromJsonBin(this@MainActivity, binUrl, key, true)
+                            Log.d("JSON AUTO SYNC>", "Auto sync completed (JSONBin)")
+                        } catch (e: Exception) {
+                            Log.e("JSON AUTO SYNC>", "Auto sync failed: ${e.message}")
+                        }
                     }
+                } else {
+                    Log.d("JSON AUTO SYNC>", "JSONBin credentials missing")
                 }
             } else {
-                Log.d("JSON AUTO SYNC>", "No personal URL configured")
+                val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, "") ?: ""
+                if (url.isNotBlank()) {
+                    Log.d("JSON AUTO SYNC>", "Starting auto sync")
+                    runBlocking {
+                        try {
+                            StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
+                            Log.d("JSON AUTO SYNC>", "Auto sync completed")
+                        } catch (e: Exception) {
+                            Log.e("JSON AUTO SYNC>", "Auto sync failed: ${e.message}")
+                        }
+                    }
+                } else {
+                    Log.d("JSON AUTO SYNC>", "No personal URL configured")
+                }
             }
         } else {
             Log.d("JSON AUTO SYNC>", "Auto sync disabled")

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -3,9 +3,13 @@ package at.plankt0n.streamplay.helper
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
+import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.data.StationItem
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 object PreferencesHelper {
 
@@ -27,9 +31,29 @@ object PreferencesHelper {
         }
     }
 
-    fun saveStations(context: Context, stationList: List<StationItem>) {
+    fun saveStations(
+        context: Context,
+        stationList: List<StationItem>,
+        syncRemote: Boolean = true
+    ) {
         val json = Gson().toJson(stationList)
         getPrefs(context).edit().putString(KEY_STATIONS, json).apply()
+
+        if (syncRemote) {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            if (prefs.getBoolean(Keys.PREF_USE_JSONBIN, false)) {
+                val url = prefs.getString(Keys.PREF_JSONBIN_URL, "") ?: ""
+                val key = prefs.getString(Keys.PREF_JSONBIN_MASTER_KEY, "") ?: ""
+                if (url.isNotBlank() && key.isNotBlank()) {
+                    GlobalScope.launch(Dispatchers.IO) {
+                        try {
+                            StationImportHelper.exportStationsToJsonBin(url, key, stationList)
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fun clearStations(context: Context) {

--- a/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/StationImportHelper.kt
@@ -5,11 +5,16 @@ import android.content.Intent
 import at.plankt0n.streamplay.StreamingService
 import at.plankt0n.streamplay.data.StationItem
 import com.google.gson.Gson
+import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URL
 import java.util.UUID
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
 object StationImportHelper {
     data class ImportStation(
@@ -67,7 +72,7 @@ object StationImportHelper {
             }
         }
 
-        PreferencesHelper.saveStations(context, stationList)
+        PreferencesHelper.saveStations(context, stationList, syncRemote = false)
         StateHelper.isPlaylistChangePending = true
         val intent = Intent(context, StreamingService::class.java).apply {
             action = "at.plankt0n.streamplay.ACTION_REFRESH_PLAYLIST"
@@ -93,6 +98,45 @@ object StationImportHelper {
             URL(normalizedUrl).openStream().bufferedReader().use { it.readText() }
         }
         return importStationsFromJson(context, json, replaceAll)
+    }
+
+    suspend fun importStationsFromJsonBin(
+        context: Context,
+        url: String,
+        masterKey: String,
+        replaceAll: Boolean
+    ): ImportResult {
+        val client = OkHttpClient()
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("X-Master-Key", masterKey)
+            .build()
+        val json = withContext(Dispatchers.IO) {
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) throw Exception("HTTP ${resp.code}")
+                val body = resp.body?.string() ?: "{}"
+                val obj = JsonParser.parseString(body).asJsonObject
+                obj["record"].toString()
+            }
+        }
+        return importStationsFromJson(context, json, replaceAll)
+    }
+
+    suspend fun exportStationsToJsonBin(
+        url: String,
+        masterKey: String,
+        stationList: List<StationItem>
+    ) {
+        val client = OkHttpClient()
+        val body = Gson().toJson(stationList).toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url(url)
+            .put(body)
+            .addHeader("X-Master-Key", masterKey)
+            .build()
+        withContext(Dispatchers.IO) {
+            client.newCall(request).execute().close()
+        }
     }
 }
 

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -370,6 +370,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         startPrefs.edit().putString(Keys.PREF_PERSONAL_SYNC_URL, defaultPersonalUrl).apply()
     }
 
+    val useJsonBinSwitch = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_USE_JSONBIN
+        title = getString(R.string.settings_use_jsonbin)
+        setDefaultValue(false)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
     val personalUrlPref = EditTextPreference(context).apply {
         key = Keys.PREF_PERSONAL_SYNC_URL
         title = getString(R.string.settings_personal_sync_url)
@@ -380,6 +388,39 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 pref.context.getString(R.string.settings_personal_sync_url_empty)
             } else {
                 value
+            }
+        }
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val jsonBinUrlPref = EditTextPreference(context).apply {
+        key = Keys.PREF_JSONBIN_URL
+        title = getString(R.string.settings_jsonbin_url)
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                value
+            }
+        }
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val jsonBinKeyPref = EditTextPreference(context).apply {
+        key = Keys.PREF_JSONBIN_MASTER_KEY
+        title = getString(R.string.settings_jsonbin_master_key)
+        setOnBindEditTextListener {
+            it.inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                "********"
             }
         }
         category = SettingsCategory.PERSONAL_SYNC
@@ -400,29 +441,70 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         category = SettingsCategory.PERSONAL_SYNC
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
         setOnPreferenceClickListener {
-            val url = personalUrlPref.text ?: ""
-            if (url.isBlank()) {
-                Toast.makeText(context, "URL erforderlich", Toast.LENGTH_SHORT).show()
+            val useJsonBin = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(Keys.PREF_USE_JSONBIN, false)
+            if (useJsonBin) {
+                val binUrl = jsonBinUrlPref.text ?: ""
+                val key = jsonBinKeyPref.text ?: ""
+                if (binUrl.isBlank() || key.isBlank()) {
+                    Toast.makeText(context, "URL und Key erforderlich", Toast.LENGTH_SHORT).show()
+                } else {
+                    this@initSettingsScreen.lifecycleScope.launch {
+                        try {
+                            val result = StationImportHelper.importStationsFromJsonBin(context, binUrl, key, true)
+                            Toast.makeText(
+                                context,
+                                "Sync abgeschlossen: ${result.added} neu, ${result.updated} aktualisiert.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        } catch (e: Exception) {
+                            Toast.makeText(
+                                context,
+                                "Fehler beim Sync: ${e.message}",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                }
             } else {
-                this@initSettingsScreen.lifecycleScope.launch {
-                    try {
-                        val result = StationImportHelper.importStationsFromUrl(context, url, true)
-                        Toast.makeText(
-                            context,
-                            "Sync abgeschlossen: ${result.added} neu, ${result.updated} aktualisiert.",
-                            Toast.LENGTH_LONG
-                        ).show()
-                    } catch (e: Exception) {
-                        Toast.makeText(
-                            context,
-                            "Fehler beim Sync: ${e.message}",
-                            Toast.LENGTH_LONG
-                        ).show()
+                val url = personalUrlPref.text ?: ""
+                if (url.isBlank()) {
+                    Toast.makeText(context, "URL erforderlich", Toast.LENGTH_SHORT).show()
+                } else {
+                    this@initSettingsScreen.lifecycleScope.launch {
+                        try {
+                            val result = StationImportHelper.importStationsFromUrl(context, url, true)
+                            Toast.makeText(
+                                context,
+                                "Sync abgeschlossen: ${result.added} neu, ${result.updated} aktualisiert.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        } catch (e: Exception) {
+                            Toast.makeText(
+                                context,
+                                "Fehler beim Sync: ${e.message}",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
                     }
                 }
             }
             true
         }
+    }
+
+    val useJsonBin = startPrefs.getBoolean(Keys.PREF_USE_JSONBIN, false)
+    useJsonBinSwitch.isChecked = useJsonBin
+    personalUrlPref.isEnabled = !useJsonBin
+    jsonBinUrlPref.isEnabled = useJsonBin
+    jsonBinKeyPref.isEnabled = useJsonBin
+
+    useJsonBinSwitch.setOnPreferenceChangeListener { _, newValue ->
+        val enabled = newValue as Boolean
+        personalUrlPref.isEnabled = !enabled
+        jsonBinUrlPref.isEnabled = enabled
+        jsonBinKeyPref.isEnabled = enabled
+        true
     }
 
     val personalExportPref = Preference(context).apply {
@@ -534,7 +616,10 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         spotifyApiKeyPref,
         spotifySecretKeyPref,
         useSpotifyMetaPref,
+        useJsonBinSwitch,
         personalUrlPref,
+        jsonBinUrlPref,
+        jsonBinKeyPref,
         autoSyncPref,
         personalSyncPref,
         personalExportPref,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,9 @@
     <string name="settings_sync_personal_json">Sync Personal JSON</string>
     <string name="settings_export_personal_json">Export Personal JSON</string>
     <string name="settings_autosync_json_startup">Autosync JSON at Startup</string>
+    <string name="settings_use_jsonbin">Use JSONBin</string>
+    <string name="settings_jsonbin_url">JSONBin URL</string>
+    <string name="settings_jsonbin_master_key">JSONBin Master Key</string>
     <string name="settings_add_test_stations">Add Test Stations</string>
     <string name="settings_import_export">Import/Export Settings</string>
     <string name="settings_export_settings">Export Settings</string>


### PR DESCRIPTION
## Summary
- add settings to switch between personal JSON URL and JSONBin sync with master key
- implement JSONBin import/export helpers and auto-sync support
- push station list changes to JSONBin when editing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd372868ac832fb341e56a2cb93733