### PR TITLE
Add CouchDB sync option for stations

### DIFF
--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -31,8 +31,6 @@ object Keys {
     const val PREF_COUCHDB_PASSWORD = "couchdb_password"
     const val PREF_AUTOSYNC_COUCHDB_STARTUP = "autosync_couchdb_startup"
     const val PREF_COUCHDB_SHOW_LOGS = "couchdb_show_logs"
-    const val DEFAULT_COUCHDB_DATABASE = "streamplay"
-    const val DEFAULT_COUCHDB_DOCUMENT = "data"
     const val PREF_ONBOARDING_DONE = "onboarding_done"
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -32,7 +32,7 @@ object Keys {
     const val PREF_AUTOSYNC_COUCHDB_STARTUP = "autosync_couchdb_startup"
     const val PREF_COUCHDB_SHOW_LOGS = "couchdb_show_logs"
     const val DEFAULT_COUCHDB_DATABASE = "streamplay"
-    const val DEFAULT_COUCHDB_DOCUMENT = "stations"
+    const val DEFAULT_COUCHDB_DOCUMENT = "data"
     const val PREF_ONBOARDING_DONE = "onboarding_done"
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -30,6 +30,7 @@ object Keys {
     const val PREF_COUCHDB_USERNAME = "couchdb_username"
     const val PREF_COUCHDB_PASSWORD = "couchdb_password"
     const val PREF_AUTOSYNC_COUCHDB_STARTUP = "autosync_couchdb_startup"
+    const val PREF_COUCHDB_SHOW_LOGS = "couchdb_show_logs"
     const val DEFAULT_COUCHDB_DATABASE = "streamplay"
     const val DEFAULT_COUCHDB_DOCUMENT = "stations"
     const val PREF_ONBOARDING_DONE = "onboarding_done"

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -30,6 +30,8 @@ object Keys {
     const val PREF_COUCHDB_USERNAME = "couchdb_username"
     const val PREF_COUCHDB_PASSWORD = "couchdb_password"
     const val PREF_AUTOSYNC_COUCHDB_STARTUP = "autosync_couchdb_startup"
+    const val DEFAULT_COUCHDB_DATABASE = "streamplay"
+    const val DEFAULT_COUCHDB_DOCUMENT = "stations"
     const val PREF_ONBOARDING_DONE = "onboarding_done"
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/Keys.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/Keys.kt
@@ -26,6 +26,10 @@ object Keys {
     const val PREF_PERSONAL_SYNC_URL = "personal_sync_url"
     const val DEFAULT_PERSONAL_SYNC_URL = "https://github.com/Planqton/streamplay/blob/main/teststations.json"
     const val PREF_AUTOSYNC_JSON_STARTUP = "autosync_json_startup"
+    const val PREF_COUCHDB_ENDPOINT = "couchdb_endpoint"
+    const val PREF_COUCHDB_USERNAME = "couchdb_username"
+    const val PREF_COUCHDB_PASSWORD = "couchdb_password"
+    const val PREF_AUTOSYNC_COUCHDB_STARTUP = "autosync_couchdb_startup"
     const val PREF_ONBOARDING_DONE = "onboarding_done"
 
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -81,7 +81,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                     Log.d("COUCHDB AUTO SYNC>", "Starting auto sync")
                     runBlocking {
                         try {
-                            CouchDbHelper.syncStations(this@MainActivity, endpoint, user, pass)
+                            CouchDbHelper.syncPrefs(this@MainActivity, endpoint, user, pass)
                             if (showLogs) {
                                 Toast.makeText(
                                     this@MainActivity,
@@ -259,6 +259,9 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         if (key == Keys.PREF_SCREEN_ORIENTATION) {
             applyOrientationPreference()
+        }
+        if (!CouchDbHelper.isApplyingPrefs) {
+            PreferencesHelper.maybePushCouchDb(this)
         }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import at.plankt0n.streamplay.data.StationItem
@@ -80,12 +81,23 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                     runBlocking {
                         try {
                             CouchDbHelper.syncStations(this@MainActivity, endpoint, user, pass)
+                            Toast.makeText(
+                                this@MainActivity,
+                                R.string.couchdb_sync_success,
+                                Toast.LENGTH_SHORT
+                            ).show()
                             Log.d("COUCHDB AUTO SYNC>", "Auto sync completed")
                         } catch (e: Exception) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                getString(R.string.couchdb_sync_failed, e.message ?: ""),
+                                Toast.LENGTH_LONG
+                            ).show()
                             Log.e("COUCHDB AUTO SYNC>", "Auto sync failed: ${e.message}")
                         }
                     }
                 } else {
+                    Toast.makeText(this, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
                     Log.d("COUCHDB AUTO SYNC>", "No endpoint configured")
                 }
             }

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -21,6 +21,7 @@ import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.ScreenOrientationMode
 import at.plankt0n.streamplay.ui.MainPagerFragment
 import at.plankt0n.streamplay.ui.DiscoverFragment
+import at.plankt0n.streamplay.helper.CouchDbHelper
 import at.plankt0n.streamplay.helper.StationImportHelper
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -69,23 +70,44 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
     private fun autoSyncIfEnabled() {
         val prefs = getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
-        if (prefs.getBoolean(Keys.PREF_AUTOSYNC_JSON_STARTUP, false)) {
-            val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, "") ?: ""
-            if (url.isNotBlank()) {
-                Log.d("JSON AUTO SYNC>", "Starting auto sync")
-                runBlocking {
-                    try {
-                        StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
-                        Log.d("JSON AUTO SYNC>", "Auto sync completed")
-                    } catch (e: Exception) {
-                        Log.e("JSON AUTO SYNC>", "Auto sync failed: ${e.message}")
+        when {
+            prefs.getBoolean(Keys.PREF_AUTOSYNC_COUCHDB_STARTUP, false) -> {
+                val endpoint = prefs.getString(Keys.PREF_COUCHDB_ENDPOINT, "") ?: ""
+                if (endpoint.isNotBlank()) {
+                    val user = prefs.getString(Keys.PREF_COUCHDB_USERNAME, "") ?: ""
+                    val pass = prefs.getString(Keys.PREF_COUCHDB_PASSWORD, "") ?: ""
+                    Log.d("COUCHDB AUTO SYNC>", "Starting auto sync")
+                    runBlocking {
+                        try {
+                            CouchDbHelper.syncStations(this@MainActivity, endpoint, user, pass)
+                            Log.d("COUCHDB AUTO SYNC>", "Auto sync completed")
+                        } catch (e: Exception) {
+                            Log.e("COUCHDB AUTO SYNC>", "Auto sync failed: ${e.message}")
+                        }
                     }
+                } else {
+                    Log.d("COUCHDB AUTO SYNC>", "No endpoint configured")
                 }
-            } else {
-                Log.d("JSON AUTO SYNC>", "No personal URL configured")
             }
-        } else {
-            Log.d("JSON AUTO SYNC>", "Auto sync disabled")
+            prefs.getBoolean(Keys.PREF_AUTOSYNC_JSON_STARTUP, false) -> {
+                val url = prefs.getString(Keys.PREF_PERSONAL_SYNC_URL, "") ?: ""
+                if (url.isNotBlank()) {
+                    Log.d("JSON AUTO SYNC>", "Starting auto sync")
+                    runBlocking {
+                        try {
+                            StationImportHelper.importStationsFromUrl(this@MainActivity, url, true)
+                            Log.d("JSON AUTO SYNC>", "Auto sync completed")
+                        } catch (e: Exception) {
+                            Log.e("JSON AUTO SYNC>", "Auto sync failed: ${e.message}")
+                        }
+                    }
+                } else {
+                    Log.d("JSON AUTO SYNC>", "No personal URL configured")
+                }
+            }
+            else -> {
+                Log.d("JSON AUTO SYNC>", "Auto sync disabled")
+            }
         }
     }
 

--- a/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/MainActivity.kt
@@ -74,6 +74,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         when {
             prefs.getBoolean(Keys.PREF_AUTOSYNC_COUCHDB_STARTUP, false) -> {
                 val endpoint = prefs.getString(Keys.PREF_COUCHDB_ENDPOINT, "") ?: ""
+                val showLogs = prefs.getBoolean(Keys.PREF_COUCHDB_SHOW_LOGS, true)
                 if (endpoint.isNotBlank()) {
                     val user = prefs.getString(Keys.PREF_COUCHDB_USERNAME, "") ?: ""
                     val pass = prefs.getString(Keys.PREF_COUCHDB_PASSWORD, "") ?: ""
@@ -81,23 +82,29 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                     runBlocking {
                         try {
                             CouchDbHelper.syncStations(this@MainActivity, endpoint, user, pass)
-                            Toast.makeText(
-                                this@MainActivity,
-                                R.string.couchdb_sync_success,
-                                Toast.LENGTH_SHORT
-                            ).show()
+                            if (showLogs) {
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    R.string.couchdb_sync_success,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
                             Log.d("COUCHDB AUTO SYNC>", "Auto sync completed")
                         } catch (e: Exception) {
-                            Toast.makeText(
-                                this@MainActivity,
-                                getString(R.string.couchdb_sync_failed, e.message ?: ""),
-                                Toast.LENGTH_LONG
-                            ).show()
+                            if (showLogs) {
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    getString(R.string.couchdb_sync_failed, e.message ?: ""),
+                                    Toast.LENGTH_LONG
+                                ).show()
+                            }
                             Log.e("COUCHDB AUTO SYNC>", "Auto sync failed: ${e.message}")
                         }
                     }
                 } else {
-                    Toast.makeText(this, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                    if (showLogs) {
+                        Toast.makeText(this, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                    }
                     Log.d("COUCHDB AUTO SYNC>", "No endpoint configured")
                 }
             }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -6,6 +6,7 @@ import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -15,6 +16,42 @@ import org.json.JSONObject
 
 object CouchDbHelper {
     private val client = OkHttpClient()
+
+    private fun buildUrls(endpoint: String): Pair<HttpUrl, HttpUrl> {
+        var fullEndpoint = endpoint.trimEnd('/')
+        var url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        if (url.pathSegments.size < 2) {
+            fullEndpoint =
+                fullEndpoint.trimEnd('/') + "/${Keys.DEFAULT_COUCHDB_DATABASE}/${Keys.DEFAULT_COUCHDB_DOCUMENT}"
+            url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        }
+        val dbUrl = url.newBuilder().removePathSegment(url.pathSegments.size - 1).build()
+        return url to dbUrl
+    }
+
+    private suspend fun ensureDatabase(dbUrl: HttpUrl, auth: String?, createIfMissing: Boolean) {
+        val headBuilder = Request.Builder().url(dbUrl)
+        auth?.let { headBuilder.header("Authorization", it) }
+        val headRequest = headBuilder.head().build()
+        val headResponse = withContext(Dispatchers.IO) { client.newCall(headRequest).execute() }
+        if (headResponse.code == 404) {
+            if (createIfMissing) {
+                val createBuilder = Request.Builder().url(dbUrl)
+                auth?.let { createBuilder.header("Authorization", it) }
+                val createRequest = createBuilder
+                    .put(ByteArray(0).toRequestBody(null))
+                    .build()
+                val createResponse = withContext(Dispatchers.IO) { client.newCall(createRequest).execute() }
+                if (createResponse.code !in 200..299) {
+                    throw Exception("HTTP ${createResponse.code}")
+                }
+            } else {
+                throw Exception("Database not found")
+            }
+        } else if (headResponse.code !in 200..299) {
+            throw Exception("HTTP ${headResponse.code}")
+        }
+    }
 
     suspend fun syncStations(
         context: Context,
@@ -27,32 +64,9 @@ object CouchDbHelper {
         } else {
             null
         }
-        var fullEndpoint = endpoint.trimEnd('/')
-        var url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
-        if (url.pathSegments.size < 2) {
-            fullEndpoint = fullEndpoint.trimEnd('/') + "/${Keys.DEFAULT_COUCHDB_DATABASE}/${Keys.DEFAULT_COUCHDB_DOCUMENT}"
-            url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
-        }
+        val (url, dbUrl) = buildUrls(endpoint)
+        ensureDatabase(dbUrl, auth, true)
 
-        val dbUrl = url.newBuilder().removePathSegment(url.pathSegments.size - 1).build()
-
-        // ensure database exists
-        val dbHeadBuilder = Request.Builder().url(dbUrl)
-        auth?.let { dbHeadBuilder.header("Authorization", it) }
-        val dbHeadRequest = dbHeadBuilder.head().build()
-        val dbHeadResponse = withContext(Dispatchers.IO) { client.newCall(dbHeadRequest).execute() }
-        if (dbHeadResponse.code == 404) {
-            val createDbBuilder = Request.Builder().url(dbUrl)
-            auth?.let { createDbBuilder.header("Authorization", it) }
-            val createDbRequest = createDbBuilder
-                .put(ByteArray(0).toRequestBody(null))
-                .build()
-            withContext(Dispatchers.IO) { client.newCall(createDbRequest).execute() }
-        } else if (dbHeadResponse.code !in 200..299) {
-            throw Exception("HTTP ${'$'}{dbHeadResponse.code}")
-        }
-
-        // fetch or create stations document
         val builder = Request.Builder().url(url)
         auth?.let { builder.header("Authorization", it) }
         val getRequest = builder.build()
@@ -75,7 +89,68 @@ object CouchDbHelper {
                 withContext(Dispatchers.IO) { client.newCall(putRequest).execute() }
             }
             else -> {
-                throw Exception("HTTP ${'$'}{response.code}")
+                throw Exception("HTTP ${response.code}")
+            }
+        }
+    }
+
+    suspend fun pushStations(
+        context: Context,
+        endpoint: String,
+        username: String,
+        password: String
+    ) {
+        val auth = if (username.isNotBlank() || password.isNotBlank()) {
+            Credentials.basic(username, password)
+        } else {
+            null
+        }
+        val (url, dbUrl) = buildUrls(endpoint)
+        ensureDatabase(dbUrl, auth, true)
+
+        val list = PreferencesHelper.getStations(context)
+        val json = Gson().toJson(mapOf("stations" to list))
+        val putBuilder = Request.Builder().url(url)
+        auth?.let { putBuilder.header("Authorization", it) }
+        val putRequest = putBuilder
+            .put(json.toRequestBody("application/json".toMediaType()))
+            .build()
+        val response = withContext(Dispatchers.IO) { client.newCall(putRequest).execute() }
+        if (response.code !in 200..299) {
+            throw Exception("HTTP ${response.code}")
+        }
+    }
+
+    suspend fun readStations(
+        context: Context,
+        endpoint: String,
+        username: String,
+        password: String
+    ) {
+        val auth = if (username.isNotBlank() || password.isNotBlank()) {
+            Credentials.basic(username, password)
+        } else {
+            null
+        }
+        val (url, dbUrl) = buildUrls(endpoint)
+        ensureDatabase(dbUrl, auth, false)
+
+        val builder = Request.Builder().url(url)
+        auth?.let { builder.header("Authorization", it) }
+        val getRequest = builder.build()
+        val response = withContext(Dispatchers.IO) { client.newCall(getRequest).execute() }
+        when (response.code) {
+            200 -> {
+                val body = response.body?.string() ?: "{}"
+                val obj = JSONObject(body)
+                val stations = obj.optJSONArray("stations")?.toString() ?: "[]"
+                StationImportHelper.importStationsFromJson(context, stations, true)
+            }
+            404 -> {
+                throw Exception("Document not found")
+            }
+            else -> {
+                throw Exception("HTTP ${response.code}")
             }
         }
     }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -1,6 +1,7 @@
 package at.plankt0n.streamplay.helper
 
 import android.content.Context
+import at.plankt0n.streamplay.Keys
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -26,8 +27,12 @@ object CouchDbHelper {
         } else {
             null
         }
-        val url = endpoint.trimEnd('/').toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
-        if (url.pathSegments.size < 2) throw IllegalArgumentException("Endpoint must include database and document")
+        var fullEndpoint = endpoint.trimEnd('/')
+        var url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        if (url.pathSegments.size < 2) {
+            fullEndpoint = fullEndpoint.trimEnd('/') + "/${Keys.DEFAULT_COUCHDB_DATABASE}/${Keys.DEFAULT_COUCHDB_DOCUMENT}"
+            url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        }
 
         val dbUrl = url.newBuilder().removePathSegment(url.pathSegments.size - 1).build()
 

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -23,12 +23,10 @@ object CouchDbHelper {
     private val client = OkHttpClient()
 
     private fun buildUrls(endpoint: String): Pair<HttpUrl, HttpUrl> {
-        var fullEndpoint = endpoint.trimEnd('/')
-        var url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        val url = endpoint.trimEnd('/').toHttpUrlOrNull()
+            ?: throw IllegalArgumentException("Invalid URL")
         if (url.pathSegments.size < 2) {
-            fullEndpoint =
-                fullEndpoint.trimEnd('/') + "/${Keys.DEFAULT_COUCHDB_DATABASE}/${Keys.DEFAULT_COUCHDB_DOCUMENT}"
-            url = fullEndpoint.toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+            throw IllegalArgumentException("Endpoint must include database and document")
         }
         val dbUrl = url.newBuilder().removePathSegment(url.pathSegments.size - 1).build()
         return url to dbUrl

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -1,0 +1,54 @@
+package at.plankt0n.streamplay.helper
+
+import android.content.Context
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+object CouchDbHelper {
+    private val client = OkHttpClient()
+
+    suspend fun syncStations(
+        context: Context,
+        endpoint: String,
+        username: String,
+        password: String
+    ) {
+        val auth = if (username.isNotBlank() || password.isNotBlank()) {
+            Credentials.basic(username, password)
+        } else {
+            null
+        }
+        val builder = Request.Builder().url(endpoint)
+        auth?.let { builder.header("Authorization", it) }
+        val getRequest = builder.build()
+        val response = withContext(Dispatchers.IO) { client.newCall(getRequest).execute() }
+        when (response.code) {
+            200 -> {
+                val body = response.body?.string() ?: "{}"
+                val obj = JSONObject(body)
+                val stations = obj.optJSONArray("stations")?.toString() ?: "[]"
+                StationImportHelper.importStationsFromJson(context, stations, true)
+            }
+            404 -> {
+                val list = PreferencesHelper.getStations(context)
+                val json = Gson().toJson(mapOf("stations" to list))
+                val putBuilder = Request.Builder().url(endpoint)
+                auth?.let { putBuilder.header("Authorization", it) }
+                val putRequest = putBuilder
+                    .put(json.toRequestBody("application/json".toMediaType()))
+                    .build()
+                withContext(Dispatchers.IO) { client.newCall(putRequest).execute() }
+            }
+            else -> {
+                throw Exception("HTTP ${'$'}{response.code}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -32,12 +32,14 @@ object CouchDbHelper {
     private suspend fun ensureDatabase(dbUrl: HttpUrl, auth: String?, createIfMissing: Boolean) {
         val headBuilder = Request.Builder().url(dbUrl)
         auth?.let { headBuilder.header("Authorization", it) }
+        headBuilder.header("Accept", "application/json")
         val headRequest = headBuilder.head().build()
         val headResponse = withContext(Dispatchers.IO) { client.newCall(headRequest).execute() }
         if (headResponse.code == 404) {
             if (createIfMissing) {
                 val createBuilder = Request.Builder().url(dbUrl)
                 auth?.let { createBuilder.header("Authorization", it) }
+                createBuilder.header("Accept", "application/json")
                 val createRequest = createBuilder
                     .put(ByteArray(0).toRequestBody(null))
                     .build()
@@ -69,6 +71,7 @@ object CouchDbHelper {
 
         val builder = Request.Builder().url(url)
         auth?.let { builder.header("Authorization", it) }
+        builder.header("Accept", "application/json")
         val getRequest = builder.build()
         val response = withContext(Dispatchers.IO) { client.newCall(getRequest).execute() }
         when (response.code) {
@@ -83,6 +86,7 @@ object CouchDbHelper {
                 val json = Gson().toJson(mapOf("stations" to list))
                 val putBuilder = Request.Builder().url(url)
                 auth?.let { putBuilder.header("Authorization", it) }
+                putBuilder.header("Accept", "application/json")
                 val putRequest = putBuilder
                     .put(json.toRequestBody("application/json".toMediaType()))
                     .build()
@@ -108,10 +112,23 @@ object CouchDbHelper {
         val (url, dbUrl) = buildUrls(endpoint)
         ensureDatabase(dbUrl, auth, true)
 
+        val getBuilder = Request.Builder().url(url)
+        auth?.let { getBuilder.header("Authorization", it) }
+        getBuilder.header("Accept", "application/json")
+        val getResponse = withContext(Dispatchers.IO) { client.newCall(getBuilder.build()).execute() }
+        val rev = when (getResponse.code) {
+            200 -> JSONObject(getResponse.body?.string() ?: "{}").optString("_rev")
+            404 -> null
+            else -> throw Exception("HTTP ${getResponse.code}")
+        }
+
         val list = PreferencesHelper.getStations(context)
-        val json = Gson().toJson(mapOf("stations" to list))
+        val data = mutableMapOf<String, Any>("stations" to list)
+        rev?.takeIf { it.isNotBlank() }?.let { data["_rev"] = it }
+        val json = Gson().toJson(data)
         val putBuilder = Request.Builder().url(url)
         auth?.let { putBuilder.header("Authorization", it) }
+        putBuilder.header("Accept", "application/json")
         val putRequest = putBuilder
             .put(json.toRequestBody("application/json".toMediaType()))
             .build()
@@ -137,6 +154,7 @@ object CouchDbHelper {
 
         val builder = Request.Builder().url(url)
         auth?.let { builder.header("Authorization", it) }
+        builder.header("Accept", "application/json")
         val getRequest = builder.build()
         val response = withContext(Dispatchers.IO) { client.newCall(getRequest).execute() }
         when (response.code) {

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -3,6 +3,8 @@ package at.plankt0n.streamplay.helper
 import android.content.Context
 import at.plankt0n.streamplay.Keys
 import com.google.gson.Gson
+import com.google.gson.JsonParser
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -15,6 +17,9 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 
 object CouchDbHelper {
+    @Volatile
+    var isApplyingPrefs = false
+        private set
     private val client = OkHttpClient()
 
     private fun buildUrls(endpoint: String): Pair<HttpUrl, HttpUrl> {
@@ -55,7 +60,7 @@ object CouchDbHelper {
         }
     }
 
-    suspend fun syncStations(
+    suspend fun syncPrefs(
         context: Context,
         endpoint: String,
         username: String,
@@ -79,11 +84,19 @@ object CouchDbHelper {
                 val body = response.body?.string() ?: "{}"
                 val obj = JSONObject(body)
                 val stations = obj.optJSONArray("stations")?.toString() ?: "[]"
-                StationImportHelper.importStationsFromJson(context, stations, true)
+                val prefsObj = obj.optJSONObject("prefs")?.toString()
+                isApplyingPrefs = true
+                try {
+                    prefsObj?.let { applyPrefs(context, it) }
+                    StationImportHelper.importStationsFromJson(context, stations, true)
+                } finally {
+                    isApplyingPrefs = false
+                }
             }
             404 -> {
                 val list = PreferencesHelper.getStations(context)
-                val json = Gson().toJson(mapOf("stations" to list))
+                val prefsMap = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE).all
+                val json = Gson().toJson(mapOf("stations" to list, "prefs" to prefsMap))
                 val putBuilder = Request.Builder().url(url)
                 auth?.let { putBuilder.header("Authorization", it) }
                 putBuilder.header("Accept", "application/json")
@@ -98,7 +111,7 @@ object CouchDbHelper {
         }
     }
 
-    suspend fun pushStations(
+    suspend fun pushPrefs(
         context: Context,
         endpoint: String,
         username: String,
@@ -123,7 +136,8 @@ object CouchDbHelper {
         }
 
         val list = PreferencesHelper.getStations(context)
-        val data = mutableMapOf<String, Any>("stations" to list)
+        val prefsMap = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE).all
+        val data = mutableMapOf<String, Any>("stations" to list, "prefs" to prefsMap)
         rev?.takeIf { it.isNotBlank() }?.let { data["_rev"] = it }
         val json = Gson().toJson(data)
         val putBuilder = Request.Builder().url(url)
@@ -138,7 +152,7 @@ object CouchDbHelper {
         }
     }
 
-    suspend fun readStations(
+    suspend fun readPrefs(
         context: Context,
         endpoint: String,
         username: String,
@@ -162,7 +176,14 @@ object CouchDbHelper {
                 val body = response.body?.string() ?: "{}"
                 val obj = JSONObject(body)
                 val stations = obj.optJSONArray("stations")?.toString() ?: "[]"
-                StationImportHelper.importStationsFromJson(context, stations, true)
+                val prefsObj = obj.optJSONObject("prefs")?.toString()
+                isApplyingPrefs = true
+                try {
+                    prefsObj?.let { applyPrefs(context, it) }
+                    StationImportHelper.importStationsFromJson(context, stations, true)
+                } finally {
+                    isApplyingPrefs = false
+                }
             }
             404 -> {
                 throw Exception("Document not found")
@@ -173,7 +194,7 @@ object CouchDbHelper {
         }
     }
 
-    suspend fun ensureStationsDocument(
+    suspend fun ensurePrefsDocument(
         context: Context,
         endpoint: String,
         username: String,
@@ -194,7 +215,8 @@ object CouchDbHelper {
         val headResponse = withContext(Dispatchers.IO) { client.newCall(headRequest).execute() }
         if (headResponse.code == 404) {
             val list = PreferencesHelper.getStations(context)
-            val json = Gson().toJson(mapOf("stations" to list))
+            val prefsMap = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE).all
+            val json = Gson().toJson(mapOf("stations" to list, "prefs" to prefsMap))
             val putBuilder = Request.Builder().url(url)
             auth?.let { putBuilder.header("Authorization", it) }
             putBuilder.header("Accept", "application/json")
@@ -208,5 +230,36 @@ object CouchDbHelper {
         } else if (headResponse.code !in 200..299) {
             throw Exception("HTTP ${headResponse.code}")
         }
+    }
+
+    private fun applyPrefs(context: Context, json: String) {
+        val obj = JsonParser.parseString(json).asJsonObject
+        val prefs = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        val editor = prefs.edit().clear()
+        for ((key, value) in obj.entrySet()) {
+            when {
+                value.isJsonPrimitive -> {
+                    val prim = value.asJsonPrimitive
+                    when {
+                        prim.isBoolean -> editor.putBoolean(key, prim.asBoolean)
+                        prim.isNumber -> {
+                            val num = prim.asNumber
+                            if (num.toString().contains('.')) {
+                                editor.putFloat(key, num.toFloat())
+                            } else {
+                                editor.putLong(key, num.toLong())
+                            }
+                        }
+                        prim.isString -> editor.putString(key, prim.asString)
+                    }
+                }
+                value.isJsonArray -> {
+                    val type = object : TypeToken<Set<String>>() {}.type
+                    val set: Set<String> = Gson().fromJson(value, type)
+                    editor.putStringSet(key, set)
+                }
+            }
+        }
+        editor.apply()
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -25,7 +26,29 @@ object CouchDbHelper {
         } else {
             null
         }
-        val builder = Request.Builder().url(endpoint)
+        val url = endpoint.trimEnd('/').toHttpUrlOrNull() ?: throw IllegalArgumentException("Invalid URL")
+        if (url.pathSegments.size < 2) throw IllegalArgumentException("Endpoint must include database and document")
+
+        val dbUrl = url.newBuilder().removePathSegment(url.pathSegments.size - 1).build()
+
+        // ensure database exists
+        val dbHeadBuilder = Request.Builder().url(dbUrl)
+        auth?.let { dbHeadBuilder.header("Authorization", it) }
+        val dbHeadRequest = dbHeadBuilder.head().build()
+        val dbHeadResponse = withContext(Dispatchers.IO) { client.newCall(dbHeadRequest).execute() }
+        if (dbHeadResponse.code == 404) {
+            val createDbBuilder = Request.Builder().url(dbUrl)
+            auth?.let { createDbBuilder.header("Authorization", it) }
+            val createDbRequest = createDbBuilder
+                .put(ByteArray(0).toRequestBody(null))
+                .build()
+            withContext(Dispatchers.IO) { client.newCall(createDbRequest).execute() }
+        } else if (dbHeadResponse.code !in 200..299) {
+            throw Exception("HTTP ${'$'}{dbHeadResponse.code}")
+        }
+
+        // fetch or create stations document
+        val builder = Request.Builder().url(url)
         auth?.let { builder.header("Authorization", it) }
         val getRequest = builder.build()
         val response = withContext(Dispatchers.IO) { client.newCall(getRequest).execute() }
@@ -39,7 +62,7 @@ object CouchDbHelper {
             404 -> {
                 val list = PreferencesHelper.getStations(context)
                 val json = Gson().toJson(mapOf("stations" to list))
-                val putBuilder = Request.Builder().url(endpoint)
+                val putBuilder = Request.Builder().url(url)
                 auth?.let { putBuilder.header("Authorization", it) }
                 val putRequest = putBuilder
                     .put(json.toRequestBody("application/json".toMediaType()))

--- a/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/CouchDbHelper.kt
@@ -172,4 +172,41 @@ object CouchDbHelper {
             }
         }
     }
+
+    suspend fun ensureStationsDocument(
+        context: Context,
+        endpoint: String,
+        username: String,
+        password: String
+    ) {
+        val auth = if (username.isNotBlank() || password.isNotBlank()) {
+            Credentials.basic(username, password)
+        } else {
+            null
+        }
+        val (url, dbUrl) = buildUrls(endpoint)
+        ensureDatabase(dbUrl, auth, true)
+
+        val headBuilder = Request.Builder().url(url)
+        auth?.let { headBuilder.header("Authorization", it) }
+        headBuilder.header("Accept", "application/json")
+        val headRequest = headBuilder.head().build()
+        val headResponse = withContext(Dispatchers.IO) { client.newCall(headRequest).execute() }
+        if (headResponse.code == 404) {
+            val list = PreferencesHelper.getStations(context)
+            val json = Gson().toJson(mapOf("stations" to list))
+            val putBuilder = Request.Builder().url(url)
+            auth?.let { putBuilder.header("Authorization", it) }
+            putBuilder.header("Accept", "application/json")
+            val putRequest = putBuilder
+                .put(json.toRequestBody("application/json".toMediaType()))
+                .build()
+            val putResponse = withContext(Dispatchers.IO) { client.newCall(putRequest).execute() }
+            if (putResponse.code !in 200..299) {
+                throw Exception("HTTP ${putResponse.code}")
+            }
+        } else if (headResponse.code !in 200..299) {
+            throw Exception("HTTP ${headResponse.code}")
+        }
+    }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -2,10 +2,17 @@ package at.plankt0n.streamplay.helper
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.widget.Toast
 import androidx.preference.PreferenceManager
+import at.plankt0n.streamplay.R
+import at.plankt0n.streamplay.Keys
 import at.plankt0n.streamplay.data.StationItem
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 object PreferencesHelper {
 
@@ -30,10 +37,12 @@ object PreferencesHelper {
     fun saveStations(context: Context, stationList: List<StationItem>) {
         val json = Gson().toJson(stationList)
         getPrefs(context).edit().putString(KEY_STATIONS, json).apply()
+        maybePushCouchDb(context)
     }
 
     fun clearStations(context: Context) {
         getPrefs(context).edit().remove(KEY_STATIONS).apply()
+        maybePushCouchDb(context)
     }
 
     fun getLastPlayedStreamIndex(context: Context): Int {
@@ -46,5 +55,37 @@ object PreferencesHelper {
             .edit()
             .putInt(PREF_LAST_PLAYED_STREAM_INDEX, index)
             .apply()
+    }
+
+    private fun maybePushCouchDb(context: Context) {
+        val settings = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+        val auto = settings.getBoolean(Keys.PREF_AUTOSYNC_COUCHDB_STARTUP, false)
+        val endpoint = settings.getString(Keys.PREF_COUCHDB_ENDPOINT, "") ?: ""
+        if (!auto || endpoint.isBlank()) return
+
+        val user = settings.getString(Keys.PREF_COUCHDB_USERNAME, "") ?: ""
+        val pass = settings.getString(Keys.PREF_COUCHDB_PASSWORD, "") ?: ""
+        val showLogs = settings.getBoolean(Keys.PREF_COUCHDB_SHOW_LOGS, true)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                CouchDbHelper.pushStations(context, endpoint, user, pass)
+                if (showLogs) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            } catch (e: Exception) {
+                if (showLogs) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.couchdb_push_failed, e.message ?: ""),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/helper/PreferencesHelper.kt
@@ -57,7 +57,8 @@ object PreferencesHelper {
             .apply()
     }
 
-    private fun maybePushCouchDb(context: Context) {
+    fun maybePushCouchDb(context: Context) {
+        if (CouchDbHelper.isApplyingPrefs) return
         val settings = context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
         val auto = settings.getBoolean(Keys.PREF_AUTOSYNC_COUCHDB_STARTUP, false)
         val endpoint = settings.getString(Keys.PREF_COUCHDB_ENDPOINT, "") ?: ""
@@ -69,7 +70,7 @@ object PreferencesHelper {
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                CouchDbHelper.pushStations(context, endpoint, user, pass)
+                CouchDbHelper.pushPrefs(context, endpoint, user, pass)
                 if (showLogs) {
                     withContext(Dispatchers.Main) {
                         Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /** Possible categories a preference can belong to. */
-enum class SettingsCategory { PLAYER, PLAYBACK, UI, METAINFO, SPOTIFY_META, PERSONAL_SYNC, ABOUT }
+enum class SettingsCategory { PLAYER, PLAYBACK, UI, METAINFO, SPOTIFY_META, PERSONAL_SYNC, COUCHDB, ABOUT }
 
 private const val EXTRA_CATEGORY = "category"
 
@@ -153,6 +153,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 SettingsCategory.METAINFO -> getString(R.string.settings_category_metainfo)
                 SettingsCategory.SPOTIFY_META -> getString(R.string.settings_category_spotify_meta)
                 SettingsCategory.PERSONAL_SYNC -> getString(R.string.settings_category_personal_sync)
+                SettingsCategory.COUCHDB -> getString(R.string.settings_category_couchdb)
                 SettingsCategory.ABOUT -> getString(R.string.settings_category_about)
             }
             icon = when (cat) {
@@ -162,6 +163,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 SettingsCategory.METAINFO -> context.getDrawable(R.drawable.ic_sheet_discover)
                 SettingsCategory.SPOTIFY_META -> context.getDrawable(R.drawable.ic_sheet_settings)
                 SettingsCategory.PERSONAL_SYNC -> context.getDrawable(R.drawable.ic_sheet_settings)
+                SettingsCategory.COUCHDB -> context.getDrawable(R.drawable.ic_sheet_settings)
                 SettingsCategory.ABOUT -> context.getDrawable(R.mipmap.ic_launcher)
             }
         }
@@ -448,21 +450,21 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 value
             }
         }
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
     val couchUserPref = EditTextPreference(context).apply {
         key = Keys.PREF_COUCHDB_USERNAME
         title = getString(R.string.settings_couchdb_username)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
     val couchPasswordPref = EditTextPreference(context).apply {
         key = Keys.PREF_COUCHDB_PASSWORD
         title = getString(R.string.settings_couchdb_password)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
@@ -470,7 +472,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         key = Keys.PREF_COUCHDB_SHOW_LOGS
         title = getString(R.string.settings_couchdb_show_logs)
         setDefaultValue(true)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
@@ -478,14 +480,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         key = Keys.PREF_AUTOSYNC_COUCHDB_STARTUP
         title = getString(R.string.settings_autosync_couchdb_startup)
         setDefaultValue(false)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
     val couchPushPref = Preference(context).apply {
         key = "couchdb_push"
         title = getString(R.string.settings_couchdb_push)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
         setOnPreferenceClickListener {
             val endpoint = couchEndpointPref.text ?: ""
@@ -520,7 +522,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
     val couchReadPref = Preference(context).apply {
         key = "couchdb_read"
         title = getString(R.string.settings_couchdb_read)
-        category = SettingsCategory.PERSONAL_SYNC
+        category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
         setOnPreferenceClickListener {
             val endpoint = couchEndpointPref.text ?: ""

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -436,6 +436,74 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         }
     }
 
+    val couchEndpointPref = EditTextPreference(context).apply {
+        key = Keys.PREF_COUCHDB_ENDPOINT
+        title = getString(R.string.settings_couchdb_endpoint)
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                value
+            }
+        }
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val couchUserPref = EditTextPreference(context).apply {
+        key = Keys.PREF_COUCHDB_USERNAME
+        title = getString(R.string.settings_couchdb_username)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val couchPasswordPref = EditTextPreference(context).apply {
+        key = Keys.PREF_COUCHDB_PASSWORD
+        title = getString(R.string.settings_couchdb_password)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val couchAutoSyncPref = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_AUTOSYNC_COUCHDB_STARTUP
+        title = getString(R.string.settings_autosync_couchdb_startup)
+        setDefaultValue(false)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    fun updateSyncPreferenceStates() {
+        val couchEnabled = couchAutoSyncPref.isChecked
+        val jsonEnabled = autoSyncPref.isChecked
+        couchEndpointPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
+        couchUserPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
+        couchPasswordPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
+        personalUrlPref.isEnabled = !couchEnabled
+        personalSyncPref.isEnabled = !couchEnabled
+        personalExportPref.isEnabled = !couchEnabled
+        autoSyncPref.isEnabled = !couchEnabled
+        couchAutoSyncPref.isEnabled = !jsonEnabled
+    }
+
+    couchAutoSyncPref.setOnPreferenceChangeListener { _, newValue ->
+        val enabled = newValue as Boolean
+        if (enabled) {
+            autoSyncPref.isChecked = false
+        }
+        updateSyncPreferenceStates()
+        true
+    }
+
+    autoSyncPref.setOnPreferenceChangeListener { _, newValue ->
+        val enabled = newValue as Boolean
+        if (enabled) {
+            couchAutoSyncPref.isChecked = false
+        }
+        updateSyncPreferenceStates()
+        true
+    }
+
     val versionPref = Preference(context).apply {
         key = "app_version"
         title = getString(R.string.settings_app_version)
@@ -538,6 +606,10 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         autoSyncPref,
         personalSyncPref,
         personalExportPref,
+        couchEndpointPref,
+        couchUserPref,
+        couchPasswordPref,
+        couchAutoSyncPref,
         versionPref,
         updatePref,
         addTestPref,
@@ -556,4 +628,5 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
     preferenceScreen = screen
 
     updateSpotifyToggle()
+    updateSyncPreferenceStates()
 }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -457,6 +457,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
     val couchUserPref = EditTextPreference(context).apply {
         key = Keys.PREF_COUCHDB_USERNAME
         title = getString(R.string.settings_couchdb_username)
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                value
+            }
+        }
         category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
@@ -464,6 +472,14 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
     val couchPasswordPref = EditTextPreference(context).apply {
         key = Keys.PREF_COUCHDB_PASSWORD
         title = getString(R.string.settings_couchdb_password)
+        summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+            val value = pref.text
+            if (value.isNullOrBlank()) {
+                pref.context.getString(R.string.settings_personal_sync_url_empty)
+            } else {
+                buildString { repeat(value.length) { append('•') } }
+            }
+        }
         category = SettingsCategory.COUCHDB
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
@@ -492,24 +508,30 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setOnPreferenceClickListener {
             val endpoint = couchEndpointPref.text ?: ""
             if (endpoint.isNotBlank()) {
-                val user = couchUserPref.text ?: ""
-                val pass = couchPasswordPref.text ?: ""
-                this@initSettingsScreen.lifecycleScope.launch {
-                    try {
-                        CouchDbHelper.pushPrefs(context, endpoint, user, pass)
-                        if (couchShowLogsPref.isChecked) {
-                            Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()
-                        }
-                    } catch (e: Exception) {
-                        if (couchShowLogsPref.isChecked) {
-                            Toast.makeText(
-                                context,
-                                getString(R.string.couchdb_push_failed, e.message ?: ""),
-                                Toast.LENGTH_LONG
-                            ).show()
+                AlertDialog.Builder(context)
+                    .setMessage(R.string.couchdb_confirm_push)
+                    .setPositiveButton(R.string.couchdb_yes) { _, _ ->
+                        val user = couchUserPref.text ?: ""
+                        val pass = couchPasswordPref.text ?: ""
+                        this@initSettingsScreen.lifecycleScope.launch {
+                            try {
+                                CouchDbHelper.pushPrefs(context, endpoint, user, pass)
+                                if (couchShowLogsPref.isChecked) {
+                                    Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()
+                                }
+                            } catch (e: Exception) {
+                                if (couchShowLogsPref.isChecked) {
+                                    Toast.makeText(
+                                        context,
+                                        getString(R.string.couchdb_push_failed, e.message ?: ""),
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
+                            }
                         }
                     }
-                }
+                    .setNegativeButton(R.string.couchdb_abort, null)
+                    .show()
             } else {
                 if (couchShowLogsPref.isChecked) {
                     Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
@@ -527,24 +549,30 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         setOnPreferenceClickListener {
             val endpoint = couchEndpointPref.text ?: ""
             if (endpoint.isNotBlank()) {
-                val user = couchUserPref.text ?: ""
-                val pass = couchPasswordPref.text ?: ""
-                this@initSettingsScreen.lifecycleScope.launch {
-                    try {
-                        CouchDbHelper.readPrefs(context, endpoint, user, pass)
-                        if (couchShowLogsPref.isChecked) {
-                            Toast.makeText(context, R.string.couchdb_read_success, Toast.LENGTH_SHORT).show()
-                        }
-                    } catch (e: Exception) {
-                        if (couchShowLogsPref.isChecked) {
-                            Toast.makeText(
-                                context,
-                                getString(R.string.couchdb_read_failed, e.message ?: ""),
-                                Toast.LENGTH_LONG
-                            ).show()
+                AlertDialog.Builder(context)
+                    .setMessage(R.string.couchdb_confirm_read)
+                    .setPositiveButton(R.string.couchdb_yes) { _, _ ->
+                        val user = couchUserPref.text ?: ""
+                        val pass = couchPasswordPref.text ?: ""
+                        this@initSettingsScreen.lifecycleScope.launch {
+                            try {
+                                CouchDbHelper.readPrefs(context, endpoint, user, pass)
+                                if (couchShowLogsPref.isChecked) {
+                                    Toast.makeText(context, R.string.couchdb_read_success, Toast.LENGTH_SHORT).show()
+                                }
+                            } catch (e: Exception) {
+                                if (couchShowLogsPref.isChecked) {
+                                    Toast.makeText(
+                                        context,
+                                        getString(R.string.couchdb_read_failed, e.message ?: ""),
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
+                            }
                         }
                     }
-                }
+                    .setNegativeButton(R.string.couchdb_abort, null)
+                    .show()
             } else {
                 if (couchShowLogsPref.isChecked) {
                     Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -554,14 +554,13 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         }
     }
 
+    /** Ensure autosync modes remain mutually exclusive without disabling any inputs. */
     fun updateSyncPreferenceStates() {
-        val couchEnabled = couchAutoSyncPref.isChecked
-        val jsonEnabled = autoSyncPref.isChecked
-        personalUrlPref.isEnabled = !couchEnabled
-        personalSyncPref.isEnabled = !couchEnabled
-        personalExportPref.isEnabled = !couchEnabled
-        autoSyncPref.isEnabled = !couchEnabled
-        couchAutoSyncPref.isEnabled = !jsonEnabled
+        if (couchAutoSyncPref.isChecked) {
+            autoSyncPref.isChecked = false
+        } else if (autoSyncPref.isChecked) {
+            couchAutoSyncPref.isChecked = false
+        }
     }
 
     couchAutoSyncPref.setOnPreferenceChangeListener { _, newValue ->

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -496,7 +496,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 val pass = couchPasswordPref.text ?: ""
                 this@initSettingsScreen.lifecycleScope.launch {
                     try {
-                        CouchDbHelper.pushStations(context, endpoint, user, pass)
+                        CouchDbHelper.pushPrefs(context, endpoint, user, pass)
                         if (couchShowLogsPref.isChecked) {
                             Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()
                         }
@@ -531,7 +531,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 val pass = couchPasswordPref.text ?: ""
                 this@initSettingsScreen.lifecycleScope.launch {
                     try {
-                        CouchDbHelper.readStations(context, endpoint, user, pass)
+                        CouchDbHelper.readPrefs(context, endpoint, user, pass)
                         if (couchShowLogsPref.isChecked) {
                             Toast.makeText(context, R.string.couchdb_read_success, Toast.LENGTH_SHORT).show()
                         }
@@ -573,7 +573,7 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 val pass = couchPasswordPref.text ?: ""
                 lifecycleScope.launch {
                     try {
-                        CouchDbHelper.ensureStationsDocument(context, endpoint, user, pass)
+                        CouchDbHelper.ensurePrefsDocument(context, endpoint, user, pass)
                         if (couchShowLogsPref.isChecked) {
                             Toast.makeText(context, R.string.couchdb_ready, Toast.LENGTH_SHORT).show()
                         }

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -573,9 +573,9 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 val pass = couchPasswordPref.text ?: ""
                 lifecycleScope.launch {
                     try {
-                        CouchDbHelper.syncStations(context, endpoint, user, pass)
+                        CouchDbHelper.ensureStationsDocument(context, endpoint, user, pass)
                         if (couchShowLogsPref.isChecked) {
-                            Toast.makeText(context, R.string.couchdb_sync_success, Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, R.string.couchdb_ready, Toast.LENGTH_SHORT).show()
                         }
                     } catch (e: Exception) {
                         if (couchShowLogsPref.isChecked) {

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -466,12 +466,90 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
     }
 
+    val couchShowLogsPref = SwitchPreferenceCompat(context).apply {
+        key = Keys.PREF_COUCHDB_SHOW_LOGS
+        title = getString(R.string.settings_couchdb_show_logs)
+        setDefaultValue(true)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
     val couchAutoSyncPref = SwitchPreferenceCompat(context).apply {
         key = Keys.PREF_AUTOSYNC_COUCHDB_STARTUP
         title = getString(R.string.settings_autosync_couchdb_startup)
         setDefaultValue(false)
         category = SettingsCategory.PERSONAL_SYNC
         icon = context.getDrawable(R.drawable.ic_sheet_settings)
+    }
+
+    val couchPushPref = Preference(context).apply {
+        key = "couchdb_push"
+        title = getString(R.string.settings_couchdb_push)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        setOnPreferenceClickListener {
+            val endpoint = couchEndpointPref.text ?: ""
+            if (endpoint.isNotBlank()) {
+                val user = couchUserPref.text ?: ""
+                val pass = couchPasswordPref.text ?: ""
+                this@initSettingsScreen.lifecycleScope.launch {
+                    try {
+                        CouchDbHelper.pushStations(context, endpoint, user, pass)
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(context, R.string.couchdb_push_success, Toast.LENGTH_SHORT).show()
+                        }
+                    } catch (e: Exception) {
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(
+                                context,
+                                getString(R.string.couchdb_push_failed, e.message ?: ""),
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                }
+            } else {
+                if (couchShowLogsPref.isChecked) {
+                    Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                }
+            }
+            true
+        }
+    }
+
+    val couchReadPref = Preference(context).apply {
+        key = "couchdb_read"
+        title = getString(R.string.settings_couchdb_read)
+        category = SettingsCategory.PERSONAL_SYNC
+        icon = context.getDrawable(R.drawable.ic_sheet_settings)
+        setOnPreferenceClickListener {
+            val endpoint = couchEndpointPref.text ?: ""
+            if (endpoint.isNotBlank()) {
+                val user = couchUserPref.text ?: ""
+                val pass = couchPasswordPref.text ?: ""
+                this@initSettingsScreen.lifecycleScope.launch {
+                    try {
+                        CouchDbHelper.readStations(context, endpoint, user, pass)
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(context, R.string.couchdb_read_success, Toast.LENGTH_SHORT).show()
+                        }
+                    } catch (e: Exception) {
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(
+                                context,
+                                getString(R.string.couchdb_read_failed, e.message ?: ""),
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                }
+            } else {
+                if (couchShowLogsPref.isChecked) {
+                    Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                }
+            }
+            true
+        }
     }
 
     fun updateSyncPreferenceStates() {
@@ -495,18 +573,24 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 lifecycleScope.launch {
                     try {
                         CouchDbHelper.syncStations(context, endpoint, user, pass)
-                        Toast.makeText(context, R.string.couchdb_sync_success, Toast.LENGTH_SHORT).show()
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(context, R.string.couchdb_sync_success, Toast.LENGTH_SHORT).show()
+                        }
                     } catch (e: Exception) {
-                        Toast.makeText(
-                            context,
-                            getString(R.string.couchdb_sync_failed, e.message ?: ""),
-                            Toast.LENGTH_LONG
-                        ).show()
+                        if (couchShowLogsPref.isChecked) {
+                            Toast.makeText(
+                                context,
+                                getString(R.string.couchdb_sync_failed, e.message ?: ""),
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
                         couchAutoSyncPref.isChecked = false
                     }
                 }
             } else {
-                Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                if (couchShowLogsPref.isChecked) {
+                    Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                }
                 return@setOnPreferenceChangeListener false
             }
         }
@@ -628,7 +712,10 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         couchEndpointPref,
         couchUserPref,
         couchPasswordPref,
+        couchShowLogsPref,
         couchAutoSyncPref,
+        couchPushPref,
+        couchReadPref,
         versionPref,
         updatePref,
         addTestPref,

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -19,6 +19,7 @@ import at.plankt0n.streamplay.data.CoverMode
 import at.plankt0n.streamplay.helper.LiveCoverHelper
 import at.plankt0n.streamplay.helper.PreferencesHelper
 import at.plankt0n.streamplay.helper.StationImportHelper
+import at.plankt0n.streamplay.helper.CouchDbHelper
 import com.google.gson.Gson
 import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
@@ -476,9 +477,6 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
     fun updateSyncPreferenceStates() {
         val couchEnabled = couchAutoSyncPref.isChecked
         val jsonEnabled = autoSyncPref.isChecked
-        couchEndpointPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
-        couchUserPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
-        couchPasswordPref.isEnabled = couchEnabled && couchAutoSyncPref.isEnabled
         personalUrlPref.isEnabled = !couchEnabled
         personalSyncPref.isEnabled = !couchEnabled
         personalExportPref.isEnabled = !couchEnabled
@@ -490,6 +488,18 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
         val enabled = newValue as Boolean
         if (enabled) {
             autoSyncPref.isChecked = false
+            val endpoint = couchEndpointPref.text ?: ""
+            if (endpoint.isNotBlank()) {
+                val user = couchUserPref.text ?: ""
+                val pass = couchPasswordPref.text ?: ""
+                lifecycleScope.launch {
+                    try {
+                        CouchDbHelper.syncStations(context, endpoint, user, pass)
+                    } catch (e: Exception) {
+                        // ignore
+                    }
+                }
+            }
         }
         updateSyncPreferenceStates()
         true

--- a/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/Settings.kt
@@ -495,10 +495,19 @@ fun PreferenceFragmentCompat.initSettingsScreen() {
                 lifecycleScope.launch {
                     try {
                         CouchDbHelper.syncStations(context, endpoint, user, pass)
+                        Toast.makeText(context, R.string.couchdb_sync_success, Toast.LENGTH_SHORT).show()
                     } catch (e: Exception) {
-                        // ignore
+                        Toast.makeText(
+                            context,
+                            getString(R.string.couchdb_sync_failed, e.message ?: ""),
+                            Toast.LENGTH_LONG
+                        ).show()
+                        couchAutoSyncPref.isChecked = false
                     }
                 }
+            } else {
+                Toast.makeText(context, R.string.couchdb_endpoint_required, Toast.LENGTH_LONG).show()
+                return@setOnPreferenceChangeListener false
             }
         }
         updateSyncPreferenceStates()

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -327,6 +327,9 @@ class StationsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        stationList.clear()
+        stationList.addAll(PreferencesHelper.getStations(requireContext()))
+        adapter.notifyDataSetChanged()
         parentFragment?.view
             ?.findViewById<ViewPager2>(R.id.main_view_pager)
             ?.isUserInputEnabled = false

--- a/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
+++ b/app/src/main/java/at/plankt0n/streamplay/ui/StationsFragment.kt
@@ -1,7 +1,9 @@
 package at.plankt0n.streamplay.ui
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -42,7 +44,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.*
 
-class StationsFragment : Fragment() {
+class StationsFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeListener {
 
     private lateinit var stationList: MutableList<StationItem>
     private lateinit var recyclerView: RecyclerView
@@ -51,6 +53,7 @@ class StationsFragment : Fragment() {
     private lateinit var topbarBackButton: ImageButton
     private lateinit var topbarTitle: TextView
     private var backPressedCallback: OnBackPressedCallback? = null
+    private lateinit var stationPrefs: SharedPreferences
 
     companion object {
         private const val REQUEST_CODE_IMPORT_JSON = 1001
@@ -66,6 +69,7 @@ class StationsFragment : Fragment() {
         topbarTitle = view.findViewById(R.id.topbar_title)
 
         stationList = PreferencesHelper.getStations(requireContext()).toMutableList()
+        stationPrefs = requireContext().getSharedPreferences("MyPrefs", Context.MODE_PRIVATE)
 
         recyclerView = view.findViewById(R.id.recyclerViewStations)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
@@ -327,6 +331,7 @@ class StationsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        stationPrefs.registerOnSharedPreferenceChangeListener(this)
         stationList.clear()
         stationList.addAll(PreferencesHelper.getStations(requireContext()))
         adapter.notifyDataSetChanged()
@@ -345,6 +350,7 @@ class StationsFragment : Fragment() {
     }
 
     override fun onPause() {
+        stationPrefs.unregisterOnSharedPreferenceChangeListener(this)
         backPressedCallback?.remove()
         backPressedCallback = null
 
@@ -357,5 +363,13 @@ class StationsFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         mediaServiceController.disconnect()
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key == "stations") {
+            stationList.clear()
+            stationList.addAll(PreferencesHelper.getStations(requireContext()))
+            adapter.notifyDataSetChanged()
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,10 @@
     <string name="settings_sync_personal_json">Sync Personal JSON</string>
     <string name="settings_export_personal_json">Export Personal JSON</string>
     <string name="settings_autosync_json_startup">Autosync JSON at Startup</string>
+    <string name="settings_couchdb_endpoint">CouchDB Endpoint</string>
+    <string name="settings_couchdb_username">CouchDB Username</string>
+    <string name="settings_couchdb_password">CouchDB Password</string>
+    <string name="settings_autosync_couchdb_startup">Autosync CouchDB at Startup</string>
     <string name="settings_add_test_stations">Add Test Stations</string>
     <string name="settings_import_export">Import/Export Settings</string>
     <string name="settings_export_settings">Export Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,4 +197,5 @@
     <string name="couchdb_read_success">CouchDB read completed</string>
     <string name="couchdb_read_failed">CouchDB read failed: %1$s</string>
     <string name="couchdb_endpoint_required">CouchDB endpoint required</string>
+    <string name="couchdb_ready">CouchDB document ready</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,4 +186,7 @@
     <string name="settings_audiofocus_hold">Hold Audiofocus</string>
     <string name="settings_audiofocus_lower">Lower Audio</string>
     <string name="settings_resume_live_after_pause">Resume Live After Pause</string>
+    <string name="couchdb_sync_success">CouchDB sync completed</string>
+    <string name="couchdb_sync_failed">CouchDB sync failed: %1$s</string>
+    <string name="couchdb_endpoint_required">CouchDB endpoint required</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="settings_category_metainfo">Metainfo Settings</string>
     <string name="settings_category_spotify_meta">Spotify Meta</string>
     <string name="settings_category_personal_sync">Personal Sync</string>
+    <string name="settings_category_couchdb">CouchDB</string>
     <string name="settings_category_about">About</string>
     <string name="settings_category_player">Player settings</string>
     <string name="settings_app_version">App Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,9 @@
     <string name="settings_couchdb_username">CouchDB Username</string>
     <string name="settings_couchdb_password">CouchDB Password</string>
     <string name="settings_autosync_couchdb_startup">Autosync CouchDB at Startup</string>
+    <string name="settings_couchdb_show_logs">Show CouchDB logs</string>
+    <string name="settings_couchdb_push">Push to CouchDB</string>
+    <string name="settings_couchdb_read">Read from CouchDB</string>
     <string name="settings_add_test_stations">Add Test Stations</string>
     <string name="settings_import_export">Import/Export Settings</string>
     <string name="settings_export_settings">Export Settings</string>
@@ -188,5 +191,9 @@
     <string name="settings_resume_live_after_pause">Resume Live After Pause</string>
     <string name="couchdb_sync_success">CouchDB sync completed</string>
     <string name="couchdb_sync_failed">CouchDB sync failed: %1$s</string>
+    <string name="couchdb_push_success">CouchDB push completed</string>
+    <string name="couchdb_push_failed">CouchDB push failed: %1$s</string>
+    <string name="couchdb_read_success">CouchDB read completed</string>
+    <string name="couchdb_read_failed">CouchDB read failed: %1$s</string>
     <string name="couchdb_endpoint_required">CouchDB endpoint required</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="settings_category_metainfo">Metainfo Settings</string>
     <string name="settings_category_spotify_meta">Spotify Meta</string>
     <string name="settings_category_personal_sync">Personal Sync</string>
-    <string name="settings_category_couchdb">CouchDB</string>
+    <string name="settings_category_couchdb">CouchDB (Sync Settings &amp; Stations)</string>
     <string name="settings_category_about">About</string>
     <string name="settings_category_player">Player settings</string>
     <string name="settings_app_version">App Version</string>
@@ -198,4 +198,8 @@
     <string name="couchdb_read_failed">CouchDB read failed: %1$s</string>
     <string name="couchdb_endpoint_required">CouchDB endpoint required</string>
     <string name="couchdb_ready">CouchDB document ready</string>
+    <string name="couchdb_confirm_push">Push to CouchDB?</string>
+    <string name="couchdb_confirm_read">Read from CouchDB?</string>
+    <string name="couchdb_yes">Yes</string>
+    <string name="couchdb_abort">Abort</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow syncing station list from CouchDB with endpoint, user, and password
- ensure CouchDB and personal JSON autosync options are mutually exclusive
- auto-create CouchDB document when missing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd521be09c832f9fb854bbac8e543c